### PR TITLE
Improving tests setup

### DIFF
--- a/lib/generators/folio/blog/templates/test/controllers/folio/console/application_dir_namespace/blog/articles_controller_test.rb.tt
+++ b/lib/generators/folio/blog/templates/test/controllers/folio/console/application_dir_namespace/blog/articles_controller_test.rb.tt
@@ -5,47 +5,60 @@ require "test_helper"
 class Folio::Console::<%= application_module %>::Blog::ArticlesControllerTest < Folio::Console::BaseControllerTest
   test "index" do
     get url_for([:console, <%= application_module %>::Blog::Article])
+
     assert_response :success
+
     create(:<%= application_dir_namespace %>_blog_article)
+
     get url_for([:console, <%= application_module %>::Blog::Article])
+
     assert_response :success
   end
 
   test "new" do
     get url_for([:console, <%= application_module %>::Blog::Article, action: :new])
+
     assert_response :success
   end
 
   test "edit" do
     model = create(:<%= application_dir_namespace %>_blog_article)
+
     get url_for([:edit, :console, model])
+
     assert_response :success
   end
 
   test "create" do
     params = build(:<%= application_dir_namespace %>_blog_article).serializable_hash
     assert_equal(0, <%= application_module %>::Blog::Article.count)
+
     post url_for([:console, <%= application_module %>::Blog::Article]), params: {
       <%= application_dir_namespace %>_blog_article: params,
     }
+
     assert_equal(1, <%= application_module %>::Blog::Article.count, "Creates record")
   end
 
   test "update" do
     model = create(:<%= application_dir_namespace %>_blog_article)
     assert_not_equal("Title", model.title)
+
     put url_for([:console, model]), params: {
       <%= application_dir_namespace %>_blog_article: {
         title: "Title",
       },
     }
+
     assert_redirected_to url_for([:edit, :console, model])
     assert_equal("Title", model.reload.title)
   end
 
   test "destroy" do
     model = create(:<%= application_dir_namespace %>_blog_article)
+
     delete url_for([:console, model])
+
     assert_redirected_to url_for([:console, <%= application_module %>::Blog::Article])
     assert_not(<%= application_module %>::Blog::Article.exists?(id: model.id))
   end

--- a/lib/generators/folio/blog/templates/test/controllers/folio/console/application_dir_namespace/blog/categories_controller_test.rb.tt
+++ b/lib/generators/folio/blog/templates/test/controllers/folio/console/application_dir_namespace/blog/categories_controller_test.rb.tt
@@ -5,47 +5,60 @@ require "test_helper"
 class Folio::Console::<%= application_module %>::Blog::CategoriesControllerTest < Folio::Console::BaseControllerTest
   test "index" do
     get url_for([:console, <%= application_module %>::Blog::Category])
+
     assert_response :success
+
     create(:<%= application_dir_namespace %>_blog_category)
+
     get url_for([:console, <%= application_module %>::Blog::Category])
+
     assert_response :success
   end
 
   test "new" do
     get url_for([:console, <%= application_module %>::Blog::Category, action: :new])
+
     assert_response :success
   end
 
   test "edit" do
     model = create(:<%= application_dir_namespace %>_blog_category)
+
     get url_for([:edit, :console, model])
+
     assert_response :success
   end
 
   test "create" do
     params = build(:<%= application_dir_namespace %>_blog_category).serializable_hash
     assert_equal(0, <%= application_module %>::Blog::Category.count)
+
     post url_for([:console, <%= application_module %>::Blog::Category]), params: {
       <%= application_dir_namespace %>_blog_category: params,
     }
+
     assert_equal(1, <%= application_module %>::Blog::Category.count, "Creates record")
   end
 
   test "update" do
     model = create(:<%= application_dir_namespace %>_blog_category)
     assert_not_equal("Title", model.title)
+
     put url_for([:console, model]), params: {
       <%= application_dir_namespace %>_blog_category: {
         title: "Title",
       },
     }
+
     assert_redirected_to url_for([:edit, :console, model])
     assert_equal("Title", model.reload.title)
   end
 
   test "destroy" do
     model = create(:<%= application_dir_namespace %>_blog_category)
+
     delete url_for([:console, model])
+
     assert_redirected_to url_for([:console, <%= application_module %>::Blog::Category])
     assert_not(<%= application_module %>::Blog::Category.exists?(id: model.id))
   end

--- a/lib/generators/folio/console/scaffold/templates/controller_test.rb.tt
+++ b/lib/generators/folio/console/scaffold/templates/controller_test.rb.tt
@@ -5,47 +5,60 @@ require "test_helper"
 class Folio::Console::<%= controller_class_name %>ControllerTest < Folio::Console::BaseControllerTest
   test "index" do
     get url_for([:console, <%= class_name %>])
+
     assert_response :success
+
     create(:<%= singular_table_name %>)
+
     get url_for([:console, <%= class_name %>])
+
     assert_response :success
   end
 
   test "new" do
     get url_for([:console, <%= class_name %>, action: :new])
+
     assert_response :success
   end
 
   test "edit" do
     model = create(:<%= singular_table_name %>)
+
     get url_for([:edit, :console, model])
+
     assert_response :success
   end
 
   test "create" do
     params = build(:<%= singular_table_name %>).serializable_hash
     assert_equal(0, <%= class_name %>.count)
+
     post url_for([:console, <%= class_name %>]), params: {
       <%= singular_table_name %>: params,
     }
+
     assert_equal(1, <%= class_name %>.count, "Creates record")
   end
 
   test "update" do
     model = create(:<%= singular_table_name %>)
     assert_not_equal("Title", model.title)
+
     put url_for([:console, model]), params: {
       <%= singular_table_name %>: {
         title: "Title",
       },
     }
+
     assert_redirected_to url_for([:edit, :console, model])
     assert_equal("Title", model.reload.title)
   end
 
   test "destroy" do
     model = create(:<%= singular_table_name %>)
+
     delete url_for([:console, model])
+
     assert_redirected_to url_for([:console, <%= class_name %>])
     assert_not(<%= class_name %>.exists?(id: model.id))
   end

--- a/test/cells/folio/publishable_hint_cell_test.rb
+++ b/test/cells/folio/publishable_hint_cell_test.rb
@@ -9,22 +9,25 @@ class Folio::PublishableHintCellTest < ActionDispatch::IntegrationTest
     create(:folio_site)
 
     @page = create(:folio_page)
-    visit url_for([@page, locale: @page.locale])
-    assert_not page.has_css?(".folio-publishable-hint")
+    get url_for([@page, locale: @page.locale])
+    assert_select ".folio-publishable-hint", false
 
     @page.update!(published: false)
     assert_raises(ActiveRecord::RecordNotFound) do
-      visit url_for([@page, locale: @page.locale])
+      get url_for([@page, locale: @page.locale])
     end
 
     account = create(:folio_admin_account)
     login_as(account, scope: :account)
 
-    visit url_for([@page, locale: @page.locale])
-    assert page.has_css?(".folio-publishable-hint")
+    get url_for([@page, locale: @page.locale])
+
+    assert_redirected_to url_for([:preview, @page]) # , locale: @page.locale])
+    follow_redirect!
+    assert_select ".folio-publishable-hint"
 
     @page.update!(published: true)
-    visit url_for([@page, locale: @page.locale])
-    assert_not page.has_css?(".folio-publishable-hint")
+    get url_for([@page, locale: @page.locale])
+    assert_select ".folio-publishable-hint", false
   end
 end

--- a/test/controllers/folio/console/merges_controller_test.rb
+++ b/test/controllers/folio/console/merges_controller_test.rb
@@ -7,9 +7,10 @@ class Folio::Console::MergesControllerTest < Folio::Console::BaseControllerTest
     original = create(:folio_page)
     duplicate = create(:folio_page)
 
-    visit new_console_merge_path("Folio::Page", original, duplicate)
-    assert page.has_css?(".f-c-merges-form__form")
-    assert_not page.has_css?(".f-c-merges-form__invalid")
+    get new_console_merge_path("Folio::Page", original, duplicate)
+
+    assert_select ".f-c-merges-form__form"
+    assert_select ".f-c-merges-form__invalid", false
   end
 
   test "new - invalid" do
@@ -18,9 +19,10 @@ class Folio::Console::MergesControllerTest < Folio::Console::BaseControllerTest
     original.update_column(:title, nil)
     assert_not(original.valid?)
 
-    visit new_console_merge_path("Folio::Page", original, duplicate)
-    assert_not page.has_css?(".f-c-merges-form__form")
-    assert page.has_css?(".f-c-merges-form__invalid")
+    get new_console_merge_path("Folio::Page", original, duplicate)
+
+    assert_select ".f-c-merges-form__form", false
+    assert_select ".f-c-merges-form__invalid"
   end
 
   test "create" do

--- a/test/controllers/folio/console/pages_controller_test.rb
+++ b/test/controllers/folio/console/pages_controller_test.rb
@@ -22,23 +22,16 @@ class Folio::Console::PagesControllerTest < Folio::Console::BaseControllerTest
   test "failed edit" do
     folio_page = create(:folio_page)
 
-    visit url_for([:edit, :console, folio_page])
-    page.fill_in "page_title", with: ""
-    page.find('input[type="submit"]').click
+    put url_for([:console, folio_page]), params: { page: { title: "" } }
 
-    title_group = page.find(".form-group.page_title")
-    assert title_group[:class].include?("form-group-invalid")
-    assert_not page.has_css?(".alert-success")
+    assert_select ".form-group.page_title.form-group-invalid"
+    assert_select ".alert-success", false
 
-    page.find('input[type="submit"]').click
+    put url_for([:console, folio_page]), params: { page: { title: "foo" } }
 
-    title_group = page.find(".form-group.page_title")
-    assert title_group[:class].include?("form-group-invalid")
-    assert_not page.has_css?(".alert-success")
-
-    page.fill_in "page_title", with: "foo"
-    page.find('input[type="submit"]').click
-    assert page.has_css?(".alert-success")
+    assert_redirected_to url_for([:edit, :console, folio_page])
+    follow_redirect!
+    assert_select ".alert-success"
   end
 
   test "revision" do

--- a/test/controllers/folio/users/sessions_controller_test.rb
+++ b/test/controllers/folio/users/sessions_controller_test.rb
@@ -40,16 +40,17 @@ class Folio::Users::SessionsControllerTest < ActionDispatch::IntegrationTest
   test "pending" do
     auth = create_omniauth_authentication("foo@foo.foo", "foo")
 
-    visit main_app.new_user_session_path(pending: 1)
-    assert_not page.has_css?(".f-devise-omniauth-conflict")
+    get main_app.new_user_session_path(pending: 1)
+    assert_select ".f-devise-omniauth-conflict", false
 
+    skip "What is this test about"
     page.set_rack_session("pending_folio_authentication_id" => {
       timestamp: Time.zone.now,
       id: auth.id,
     })
 
-    visit main_app.new_user_session_path(pending: 1)
-    assert page.has_css?(".f-devise-omniauth-conflict")
+    get main_app.new_user_session_path(pending: 1)
+    assert_select ".f-devise-omniauth-conflict"
   end
 
   test "conflict_token" do

--- a/test/controllers/folio/users/sessions_controller_test.rb
+++ b/test/controllers/folio/users/sessions_controller_test.rb
@@ -38,16 +38,15 @@ class Folio::Users::SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "pending" do
-    auth = create_omniauth_authentication("foo@foo.foo", "foo")
+    user = create(:folio_user)
+    auth = create_omniauth_authentication(user.email, "foo")
+
+    assert_not auth.find_or_create_user!
 
     get main_app.new_user_session_path(pending: 1)
     assert_select ".f-devise-omniauth-conflict", false
 
-    skip "What is this test about"
-    page.set_rack_session("pending_folio_authentication_id" => {
-      timestamp: Time.zone.now,
-      id: auth.id,
-    })
+    do_omniauth_callback(auth)
 
     get main_app.new_user_session_path(pending: 1)
     assert_select ".f-devise-omniauth-conflict"
@@ -69,5 +68,9 @@ class Folio::Users::SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to main_app.send(Rails.application.config.folio_users_after_sign_in_path)
 
     assert_equal(user.id, auth.reload.folio_user_id)
+  end
+
+  def do_omniauth_callback(auth)
+    get user_facebook_omniauth_callback_url, headers: { "omniauth.auth" => omniauth_authentication_openstruct(auth.email, auth.nickname) }
   end
 end

--- a/test/integration/folio/meta_variables_test.rb
+++ b/test/integration/folio/meta_variables_test.rb
@@ -9,45 +9,26 @@ class Folio::MetaVariablesTest < ActionDispatch::IntegrationTest
     node = create(:folio_page, title: "PAGE")
 
     # node without perex
-    visit url_for(node)
+    get url_for(node)
 
-    title = page.find("title", visible: false)
-    assert_equal("PAGE | SITE", title.native.text)
+    assert_select "head title", "PAGE | SITE"
+    assert_select 'meta[name="description"][content="SITE DESCRIPTION"]'
 
-    description = page.find('meta[name="description"]',
-                            visible: false)
-    assert_equal("SITE DESCRIPTION", description[:content])
-
-    og_title = page.find('meta[property="og:title"]',
-                         visible: false)
-    assert_equal("PAGE | SITE", og_title[:content])
-
-    og_description = page.find('meta[property="og:description"]',
-                               visible: false)
-    assert_equal("SITE DESCRIPTION", og_description[:content])
+    assert_select 'meta[property="og:title"][content="PAGE | SITE"]'
+    assert_select 'meta[property="og:description"][content="SITE DESCRIPTION"]'
 
     # node with perex
     node.update!(perex: "PAGE DESCRIPTION")
-    visit url_for(node)
+    get url_for(node)
 
-    description = page.find('meta[name="description"]',
-                            visible: false)
-    assert_equal("PAGE DESCRIPTION", description[:content])
-
-    og_description = page.find('meta[property="og:description"]',
-                               visible: false)
-    assert_equal("PAGE DESCRIPTION", og_description[:content])
+    assert_select 'meta[name="description"][content="PAGE DESCRIPTION"]'
+    assert_select 'meta[property="og:description"][content="PAGE DESCRIPTION"]'
 
     # page with perex & meta_description
     node.update!(meta_description: "PAGE META DESCRIPTION")
-    visit url_for(node)
+    get url_for(node)
 
-    description = page.find('meta[name="description"]',
-                            visible: false)
-    assert_equal("PAGE META DESCRIPTION", description[:content])
-
-    og_description = page.find('meta[property="og:description"]',
-                               visible: false)
-    assert_equal("PAGE META DESCRIPTION", og_description[:content])
+    assert_select 'meta[name="description"][content="PAGE META DESCRIPTION"]'
+    assert_select 'meta[property="og:description"][content="PAGE META DESCRIPTION"]'
   end
 end

--- a/test/test_helper_base.rb
+++ b/test/test_helper_base.rb
@@ -28,20 +28,6 @@ class Folio::Console::CellTest < Cell::TestCase
   controller Folio::Console::BaseController
 end
 
-class ActionDispatch::IntegrationTest
-  # Make the Capybara DSL available in all integration tests
-  include Capybara::DSL
-  # Make `assert_*` methods behave like Minitest assertions
-  include Capybara::Minitest::Assertions
-
-  # Reset sessions and driver between tests
-  # Use super wherever this method is redefined in your individual test classes
-  def teardown
-    Capybara.reset_sessions!
-    Capybara.use_default_driver
-  end
-end
-
 class Folio::Console::BaseControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
   include Folio::Engine.routes.url_helpers


### PR DESCRIPTION
- Removed Capybara mixins from `ActionDispatch::IntegrationTest` + fixed tests which uses it
- separated `:setup + :execute + :verify_expectations`  parts in controller test templates