### PR TITLE
folio_users_registerable option + fix pro omniauth_providers empty

### DIFF
--- a/app/cells/folio/devise/sessions/new/show.slim
+++ b/app/cells/folio/devise/sessions/new/show.slim
@@ -17,5 +17,6 @@
 
     span.folio-loader.f-devise__loader
 
-  .f-devise__bottom-action-wrap
-    == register_button
+  - if ::Rails.application.config.folio_users_registerable
+    .f-devise__bottom-action-wrap
+      == register_button

--- a/app/models/folio/user.rb
+++ b/app/models/folio/user.rb
@@ -20,8 +20,11 @@ class Folio::User < Folio::ApplicationRecord
   selected_device_modules << :confirmable if Rails.application.config.folio_users_confirmable
   selected_device_modules << :omniauthable if Rails.application.config.folio_users_omniauth_providers.present?
 
-  devise(*selected_device_modules,
-         omniauth_providers: Rails.application.config.folio_users_omniauth_providers)
+  devise_options = {
+    omniauth_providers: Rails.application.config.folio_users_omniauth_providers.presence
+  }.compact
+
+  devise(*selected_device_modules, devise_options)
 
   pg_search_scope :by_query,
                   against: [:email],

--- a/app/models/folio/user.rb
+++ b/app/models/folio/user.rb
@@ -9,13 +9,14 @@ class Folio::User < Folio::ApplicationRecord
 
   selected_device_modules = %i[
     database_authenticatable
-    registerable
     recoverable
     rememberable
     trackable
     validatable
     invitable
   ]
+
+  selected_device_modules << :registerable if Rails.application.config.folio_users_registerable
   selected_device_modules << :confirmable if Rails.application.config.folio_users_confirmable
   selected_device_modules << :omniauthable if Rails.application.config.folio_users_omniauth_providers.present?
 

--- a/lib/folio/engine.rb
+++ b/lib/folio/engine.rb
@@ -40,6 +40,7 @@ module Folio
 
     config.folio_users = false
     config.folio_users_confirmable = false
+    config.folio_users_registerable = true
     config.folio_users_omniauth_providers = %i[facebook google_oauth2 twitter]
     config.folio_users_after_sign_in_path = :root_path
     config.folio_users_after_sign_up_path = :root_path

--- a/test/controllers/folio/users/sessions_controller_test.rb
+++ b/test/controllers/folio/users/sessions_controller_test.rb
@@ -37,43 +37,45 @@ class Folio::Users::SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to main_app.new_user_session_path
   end
 
-  test "pending" do
-    user = create(:folio_user)
-    auth = create_omniauth_authentication(user.email, "foo")
+  if Rails.application.config.folio_users_omniauth_providers.present?
+    test "pending" do
+      user = create(:folio_user)
+      auth = create_omniauth_authentication(user.email, "foo")
 
-    assert_not auth.find_or_create_user!
+      assert_not auth.find_or_create_user!
 
-    get main_app.new_user_session_path(pending: 1)
-    assert_select ".f-devise-omniauth-conflict", false
+      get main_app.new_user_session_path(pending: 1)
+      assert_select ".f-devise-omniauth-conflict", false
 
-    do_omniauth_callback(auth)
+      do_omniauth_callback(auth)
 
-    get main_app.new_user_session_path(pending: 1)
-    assert_select ".f-devise-omniauth-conflict"
-  end
+      get main_app.new_user_session_path(pending: 1)
+      assert_select ".f-devise-omniauth-conflict"
+    end
 
-  test "conflict_token" do
-    user = create(:folio_user)
-    auth = create_omniauth_authentication(user.email, "foo")
+    test "conflict_token" do
+      user = create(:folio_user)
+      auth = create_omniauth_authentication(user.email, "foo")
 
-    assert_not auth.find_or_create_user!
-    assert_equal(user.id, auth.reload.conflict_user_id)
+      assert_not auth.find_or_create_user!
+      assert_equal(user.id, auth.reload.conflict_user_id)
 
-    get main_app.new_user_session_path(conflict_token: "foo")
-    assert_redirected_to main_app.new_user_session_path
+      get main_app.new_user_session_path(conflict_token: "foo")
+      assert_redirected_to main_app.new_user_session_path
 
-    assert_nil(auth.reload.folio_user_id)
+      assert_nil(auth.reload.folio_user_id)
 
-    get main_app.new_user_session_path(conflict_token: auth.conflict_token)
-    assert_redirected_to main_app.send(Rails.application.config.folio_users_after_sign_in_path)
+      get main_app.new_user_session_path(conflict_token: auth.conflict_token)
+      assert_redirected_to main_app.send(Rails.application.config.folio_users_after_sign_in_path)
 
-    assert_equal(user.id, auth.reload.folio_user_id)
-  end
+      assert_equal(user.id, auth.reload.folio_user_id)
+    end
 
-  def do_omniauth_callback(auth)
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.mock_auth[:facebook] = omniauth_authentication_openstruct(auth.email, auth.nickname)
+    def do_omniauth_callback(auth)
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:facebook] = omniauth_authentication_openstruct(auth.email, auth.nickname)
 
-    get user_facebook_omniauth_callback_url, headers: { "omniauth.auth" => OmniAuth.config.mock_auth[:facebook] }
+      get user_facebook_omniauth_callback_url, headers: { "omniauth.auth" => OmniAuth.config.mock_auth[:facebook] }
+    end
   end
 end

--- a/test/controllers/folio/users/sessions_controller_test.rb
+++ b/test/controllers/folio/users/sessions_controller_test.rb
@@ -34,7 +34,7 @@ class Folio::Users::SessionsControllerTest < ActionDispatch::IntegrationTest
   test "destroy" do
     sign_in @user
     get main_app.destroy_user_session_path
-    assert_redirected_to main_app.new_user_session_path
+    assert_redirected_to main_app.send(Rails.application.config.folio_users_after_sign_out_path)
   end
 
   if Rails.application.config.folio_users_omniauth_providers.present?


### PR DESCRIPTION
upravil jsem nastaveni devise pro user
- pridal jsem `folio_users_registerable` default true, pro weby bez moznosti FE registrace, zrovna jeden ne-sinfini delam
- opravil jsem nastaveni pro weby bez omniauth
  - `omniauth_providers` nemuze byt prazdna `[]` (devise pak hazi chyby) + upravil testy sessions controlleru 