### PR TITLE
More descriptive errors on singleton validations

### DIFF
--- a/app/models/concerns/folio/localized_singleton.rb
+++ b/app/models/concerns/folio/localized_singleton.rb
@@ -19,9 +19,9 @@ module Folio::LocalizedSingleton
   private
     def validate_singularity
       if new_record?
-        errors.add(:base, :invalid) if self.class.exists?(locale:)
+        errors.add(:type, "There is already #{self.class} record for locale '#{locale}'") if self.class.exists?(locale:)
       else
-        errors.add(:base, :invalid) if self.class.where.not(id:).exists?(locale:)
+        errors.add(:type, "There is already #{self.class} record for locale '#{locale}'") if self.class.where.not(id:).exists?(locale:)
       end
     end
 end

--- a/app/models/concerns/folio/localized_singleton.rb
+++ b/app/models/concerns/folio/localized_singleton.rb
@@ -19,9 +19,9 @@ module Folio::LocalizedSingleton
   private
     def validate_singularity
       if new_record?
-        errors.add(:type, "There is already #{self.class} record for locale '#{locale}'") if self.class.exists?(locale:)
+        errors.add(:type, :already_exists_with_locale, class: self.class, rec_locale: locale) if self.class.exists?(locale:)
       else
-        errors.add(:type, "There is already #{self.class} record for locale '#{locale}'") if self.class.where.not(id:).exists?(locale:)
+        errors.add(:type, :already_exists_with_locale, class: self.class, rec_locale: locale) if self.class.where.not(id:).exists?(locale:)
       end
     end
 end

--- a/app/models/concerns/folio/singleton.rb
+++ b/app/models/concerns/folio/singleton.rb
@@ -32,9 +32,9 @@ module Folio::Singleton
   private
     def validate_singularity
       if new_record?
-        errors.add(:type, "There is already #{self.class} record") if self.class.exists?
+        errors.add(:type, :already_exists, class: self.class) if self.class.exists?
       else
-        errors.add(:type, "There is already #{self.class} record") if self.class.where.not(id:).exists?
+        errors.add(:type, :already_exists, class: self.class) if self.class.where.not(id:).exists?
       end
     end
 end

--- a/app/models/concerns/folio/singleton.rb
+++ b/app/models/concerns/folio/singleton.rb
@@ -32,9 +32,9 @@ module Folio::Singleton
   private
     def validate_singularity
       if new_record?
-        errors.add(:base, :invalid) if self.class.exists?
+        errors.add(:type, "There is already #{self.class} record") if self.class.exists?
       else
-        errors.add(:base, :invalid) if self.class.where.not(id:).exists?
+        errors.add(:type, "There is already #{self.class} record") if self.class.where.not(id:).exists?
       end
     end
 end

--- a/config/locales/activerecord.cs.yml
+++ b/config/locales/activerecord.cs.yml
@@ -133,6 +133,8 @@ cs:
           attributes:
             phone:
               invalid: nemá správný formát. Zadejte prosím celé číslo včetně předvolby. Např. +420604123456
+            password:
+              weak_password: je příliš slabé. Zkuste alespoň 8 znaků namíchaných z velkých a malých písmen, číslic a symbolů.
     models:
       folio/account:
         few: Administrátoři

--- a/config/locales/activerecord.cs.yml
+++ b/config/locales/activerecord.cs.yml
@@ -290,3 +290,6 @@ cs:
     attributes:
       verified_captcha:
         invalid: Potvrďte prosím, že nejste robot 🤖
+      type:
+        already_exists_with_locale: "Je povolen jen jeden záznam '%{class}' s 'locale = \"%{rec_locale}\"'."
+        already_exists: "Je povolen jen jeden záznam '%{class}'."

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -97,6 +97,8 @@ en:
           attributes:
             phone:
               invalid: is invalid. Please enter a full number including country code, i.e. +420604123456
+            password:
+              weak_password: is weak.Try at least 8 characters from lowercase and uppercase letters, numbers and symbols.
     models:
       folio/account:
         one: Account

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -210,3 +210,6 @@ en:
     attributes:
       verified_captcha:
         invalid: Please verify you're not a robot 🤖
+      type:
+        already_exists_with_locale: "Only one record of '%{class}' with 'locale = \"%{rec_locale}\"' is allowed."
+        already_exists: "Only one record of '%{class}' is allowed."

--- a/test/models/concerns/folio/localized_singleton_test.rb
+++ b/test/models/concerns/folio/localized_singleton_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Folio::LocalizedSingletonTest < ActiveSupport::TestCase
+  class TestLocalizedSingleton < Dummy::Menu::Header
+    include Folio::LocalizedSingleton
+  end
+
+  test "allows only one record" do
+    singletoned_class = TestLocalizedSingleton
+
+    _allowed_cz = singletoned_class.create!(locale: :cz, title: "Povolený")
+    _allowed_en = singletoned_class.create!(locale: :en, title: "Allowed")
+    not_allowed = singletoned_class.new(locale: :en, title: "Allowed2")
+
+    assert_not not_allowed.valid?
+    assert_includes(not_allowed.errors[:type],
+                    "Je povolen jen jeden záznam '#{singletoned_class}' s 'locale = \"en\"'.",
+                    not_allowed.errors.to_json)
+  end
+end

--- a/test/models/concerns/folio/singleton_test.rb
+++ b/test/models/concerns/folio/singleton_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Folio::SingletonTest < ActiveSupport::TestCase
+  test "allows only one record" do
+    singletoned_class = Dummy::Menu::Header
+
+    _allowed = singletoned_class.create!(locale: :cz, title: "Povolený")
+    not_allowed = singletoned_class.new(locale: :en, title: "Allowed")
+
+    assert_not not_allowed.valid?
+    assert_includes(not_allowed.errors[:type],
+                    "Je povolen jen jeden záznam '#{singletoned_class}'.",
+                    not_allowed.errors.to_json)
+  end
+end


### PR DESCRIPTION
Místo `ActiveRecord::RecordInvalid: Validace je neúspešná: není platná hodnota` alias `#<ActiveModel::Errors [#<ActiveModel::Error attribute=base, type=invalid, options={}>]>` se vypisuje jádro problému (Existující stejný záznam pro singleton)
