### PR TITLE
Multi-site mailing

### DIFF
--- a/app/controllers/folio/console/email_templates_controller.rb
+++ b/app/controllers/folio/console/email_templates_controller.rb
@@ -5,6 +5,7 @@ class Folio::Console::EmailTemplatesController < Folio::Console::BaseController
 
   def index
     # disable pagination
+    @email_templates = @email_templates.ordered
   end
 
   private

--- a/app/lib/folio/mailer_base.rb
+++ b/app/lib/folio/mailer_base.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Folio::MailerBase
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :site
+  end
+
+  def site
+    @site ||= Folio.site_instance_for_mailers
+  end
+
+  def system_email
+    if site.system_email.present?
+      site.system_email_array
+    else
+      site.email
+    end
+  end
+
+  def system_email_copy
+    site.system_email_copy_array if site.system_email_copy.present?
+  end
+
+  module ClassMethods
+    def site
+      logger.error("Folio deprecation: Class method `site` is deprecated, use instance method instead.")
+
+      if Rails.application.config.folio_site_is_a_singleton
+        Folio::Site.instance
+      else
+        Folio::Site.ordered.first
+      end
+    end
+
+    def system_email
+      logger.error("Folio deprecation: Class method `system_email` is deprecated, use instance method instead.")
+
+      if site.system_email.present?
+        site.system_email_array
+      else
+        site.email
+      end
+    end
+
+    def system_email_copy
+      logger.error("Folio deprecation: Class method `system_email_copy` is deprecated, use instance method instead.")
+
+      site.system_email_copy_array if site.system_email_copy.present?
+    end
+  end
+end

--- a/app/lib/folio/mailer_email_templates.rb
+++ b/app/lib/folio/mailer_email_templates.rb
@@ -8,7 +8,7 @@ module Folio::MailerEmailTemplates
     find_by = { mailer:, action: }
 
     unless Rails.application.config.folio_site_is_a_singleton
-      find_by[:site] = Folio.site_instance_for_mailers
+      find_by[:site] = site
     end
 
     if bang
@@ -24,16 +24,17 @@ module Folio::MailerEmailTemplates
 
   def email_template_mail(sym_data = {}, opts = {})
     @data = sym_data.stringify_keys
+    @site = opts.delete(:site)
     @email_template = email_template_for!
 
-    @data[:ROOT_URL] = "#{Rails.env.staging? || Rails.env.production? ? "https" : "http"}://#{Folio.site_instance_for_mailers.domain}"
-    @data[:SITE_TITLE] = Folio.site_instance_for_mailers.title
-    @data[:DOMAIN] = Folio.site_instance_for_mailers.domain
+    @data[:ROOT_URL] = site.env_aware_root_url
+    @data[:SITE_TITLE] = site.title
+    @data[:DOMAIN] = site.domain
 
     opts[:subject] = @email_template.render_subject(@data)
-    opts[:to] ||= self.class.system_email
-    opts[:cc] ||= self.class.system_email_copy
-    opts[:from] ||= Folio.site_instance_for_mailers.email
+    opts[:to] ||= system_email
+    opts[:cc] ||= system_email_copy
+    opts[:from] ||= site.email
     opts[:template_path] = "folio/email_templates"
     opts[:template_name] = "mail"
 
@@ -46,9 +47,9 @@ module Folio::MailerEmailTemplates
 
     if @email_template.present?
       @data ||= {}
-      @data[:ROOT_URL] = "#{Rails.env.staging? || Rails.env.production? ? "https" : "http"}://#{Folio.site_instance_for_mailers.domain}"
-      @data[:SITE_TITLE] = Folio.site_instance_for_mailers.title
-      @data[:DOMAIN] = Folio.site_instance_for_mailers.domain
+      @data[:ROOT_URL] = site.env_aware_root_url
+      @data[:SITE_TITLE] = site.title
+      @data[:DOMAIN] = site.domain
       @data[:USER_EMAIL] = record.email
 
       opts[:subject] = @email_template.render_subject(@data)

--- a/app/mailers/folio/aasm_mailer.rb
+++ b/app/mailers/folio/aasm_mailer.rb
@@ -8,20 +8,20 @@ class Folio::AasmMailer < Folio::ApplicationMailer
 
     mail to: email,
          subject:,
-         bcc: self.class.bcc_email,
-         reply_to: self.class.reply_to_email,
-         from: self.class.from_email
+         bcc: bcc_email,
+         reply_to: reply_to_email,
+         from: from_email
   end
 
-  def self.bcc_email
+  def bcc_email
     Rails.application.config.folio_aasm_mailer_config.try(:[], :bcc)
   end
 
-  def self.reply_to_email
+  def reply_to_email
     Rails.application.config.folio_aasm_mailer_config.try(:[], :reply_to)
   end
 
-  def self.from_email
-    Rails.application.config.folio_aasm_mailer_config.try(:[], :from) || Folio.site_instance_for_mailers.email_from.presence || Folio.site_instance_for_mailers.email
+  def from_email
+    Rails.application.config.folio_aasm_mailer_config.try(:[], :from) || site.email_from.presence || site.email
   end
 end

--- a/app/mailers/folio/application_mailer.rb
+++ b/app/mailers/folio/application_mailer.rb
@@ -2,20 +2,9 @@
 
 class Folio::ApplicationMailer < ActionMailer::Base
   include Folio::Engine.routes.url_helpers
+  include Folio::MailerBase
   include Folio::MailerEmailTemplates
 
-  default from: -> { Folio.site_instance_for_mailers.email_from.presence || Folio.site_instance_for_mailers.email }
+  default from: -> { site.email_from.presence || site.email }
   layout "folio/mailer"
-
-  def self.system_email
-    if Folio.site_instance_for_mailers.system_email.present?
-      Folio.site_instance_for_mailers.system_email_array
-    else
-      Folio.site_instance_for_mailers.email
-    end
-  end
-
-  def self.system_email_copy
-    Folio.site_instance_for_mailers.system_email_copy_array if Folio.site_instance_for_mailers.system_email_copy.present?
-  end
 end

--- a/app/mailers/folio/devise_mailer.rb
+++ b/app/mailers/folio/devise_mailer.rb
@@ -3,11 +3,12 @@
 class Folio::DeviseMailer < Devise::Mailer
   include DeviseInvitable::Mailer
   include DeviseInvitable::Controllers::Helpers
+  include Folio::MailerBase
   include Folio::MailerEmailTemplates
 
   layout "folio/mailer"
 
-  default from: ->(*) { Folio.site_instance_for_mailers.email }
+  default from: ->(*) { site.email }
 
   def devise_mail(record, action, opts = {}, &block)
     full_opts = devise_opts_from_template(opts, action, record)
@@ -45,18 +46,6 @@ class Folio::DeviseMailer < Devise::Mailer
 
     email_template_mail template_data,
                         headers_for(:omniauth_conflict, opts).merge(subject: t("devise.mailer.omniauth_conflict.subject"))
-  end
-
-  def self.system_email
-    if Folio.site_instance_for_mailers.system_email.present?
-      Folio.site_instance_for_mailers.system_email_array
-    else
-      Folio.site_instance_for_mailers.email
-    end
-  end
-
-  def self.system_email_copy
-    Folio.site_instance_for_mailers.system_email_copy_array if Folio.site_instance_for_mailers.system_email_copy.present?
   end
 
   private

--- a/app/views/layouts/folio/mailer.html.slim
+++ b/app/views/layouts/folio/mailer.html.slim
@@ -31,7 +31,7 @@ html[
                   td align="left" valign="top"
                     .f-mailer__logo-wrap
                       a.f-mailer__logo[
-                        href="#{Rails.env.staging? || Rails.env.production? ? "https" : "http"}://#{Folio.site_instance_for_mailers.domain}"
+                        href=site.env_aware_root_url
                         target="_blank"
                       ]
                         = render 'folio/mailer/logo'

--- a/lib/tasks/folio/email_templates.rake
+++ b/lib/tasks/folio/email_templates.rake
@@ -6,6 +6,10 @@ namespace :folio do
       Rails.logger.silence do
         Folio::EmailTemplate.load_templates_from_yaml(Folio::Engine.root.join("data/email_templates_data.yml"))
         Folio::EmailTemplate.load_templates_from_yaml(Rails.root.join("data/email_templates_data.yml"))
+
+        Dir[Rails.root.join("data/email_templates/*.yml")].each do |path|
+          Folio::EmailTemplate.load_templates_from_yaml(path)
+        end
       end
     end
   end


### PR DESCRIPTION
@mreq koukni na to pls, je to jen mala uprava, ale pro jistotu, folio mailery jsou spis tvoje domena

- `Folio.site_instance_for_mailers` jsem nechal + v application maileru jsem pridal metodu site ktera si site zacachuje (takze je moznost to prepsat globalne na `Folio`, pripadne na konkretnim maileru nebo per action jako v boutique ->
```
def paid(order)
  data = order_data(order)
  email_template_mail(data, to: order.email, site: order.site)
end
```
- taky jsem kvuli tomu presunul metody `system_email` a `system_email_copy` z class na instanci, class metody jsem zatim nechal s deprecation warning, aby se nevysypal nejaky starsi projekt... nejsem si jisty jestli to mit jako class metodu melo nejakou vyhodu ale prislo mi ze ne
- a jeste jsem pridal moznost pouziti vice yml souboru ve slozce `data/email_templates/*.yml`, s multisite ten jeden yml soubor strasne nabobtnal a je to opruz s tim pracovat  