### PR TITLE
Add non-compact mode to translated inputs

### DIFF
--- a/app/cells/folio/console/translated_inputs/show.slim
+++ b/app/cells/folio/console/translated_inputs/show.slim
@@ -1,13 +1,16 @@
 - if translations.present?
+  - compact_row_class = compact ? 'f-c-translated-inputs__row--compact' : ''
+  - compact_col_class = compact ? 'f-c-translated-inputs__col--compact' : ''
+
   - if translations.size == 1
     = f.input "#{key}_#{translations.first}", *args
   - else
     .f-c-translated-inputs
       = f.label key
 
-      .row.f-c-translated-inputs__row
+      .row.f-c-translated-inputs__row class=compact_row_class
         - translations.each do |locale|
-          .col-md.f-c-translated-inputs__col
+          .col-md.f-c-translated-inputs__col class=compact_col_class
             = f.input "#{key}_#{locale}".to_sym, *args_with_locale(locale)
 
       = f.hint key

--- a/app/cells/folio/console/translated_inputs/translated_inputs.sass
+++ b/app/cells/folio/console/translated_inputs/translated_inputs.sass
@@ -1,13 +1,17 @@
 .f-c-translated-inputs
   margin-bottom: $spacer
 
-  &__row
+  &__row--compact
     margin-left: - $grid-gutter-half / 2
     margin-right: - $grid-gutter-half / 2
 
   &__col
-    padding-left: $grid-gutter-half / 2
-    padding-right: $grid-gutter-half / 2
+    padding-left: $grid-gutter-half
+    padding-right: $grid-gutter-half
+
+    &--compact
+      padding-left: $grid-gutter-half / 2
+      padding-right: $grid-gutter-half / 2
 
   .form-group
     margin-bottom: 0

--- a/app/cells/folio/console/translated_inputs_cell.rb
+++ b/app/cells/folio/console/translated_inputs_cell.rb
@@ -9,6 +9,11 @@ class Folio::Console::TranslatedInputsCell < Folio::ConsoleCell
     model[:key]
   end
 
+  def compact
+    args_hash = model[:args]&.find { |arg| arg.is_a?(Hash) && arg.key?(:compact) }
+    args_hash ? args_hash[:compact] : true
+  end
+
   def args
     if translations.size == 1
       label_hash = { label: f.object.class.human_attribute_name(key) }


### PR DESCRIPTION
Do `translated_inputs` jsem přidal optional parametr compact s default hodnotou true, aby se neovlivnily stávající designy. Změnu jsem udělal k dosáhnutí konzistence odsazení mezi sloupci inputů. U `translated_inputs` (první 2 řádky inputů) bylo odsazení příliš malé a neodpovídalo designu. U `f.input` to bylo v pořádku (poslední input).
![image](https://github.com/sinfin/folio/assets/57494154/08abb3df-59f0-4c0a-991a-ad9f713a9674).

Výsledkem je teď, po předání parametru `= translated_inputs f, :slug, compact: false`, konzistentní odsazení:
![image](https://github.com/sinfin/folio/assets/57494154/32b11e87-180e-465f-99f2-73355253e555)

