### PR TITLE
auto translate traco columns using deepl free api

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ PATH
       coffee-rails (~> 5.0)
       countries
       country_select
+      deepl-rb
       devise
       devise-bootstrap-views
       devise-i18n
@@ -269,6 +270,7 @@ GEM
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
+    deepl-rb (2.5.3)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)

--- a/app/models/concerns/folio/auto_translate_for_traco.rb
+++ b/app/models/concerns/folio/auto_translate_for_traco.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "deepl"
+
+module Folio::AutoTranslateForTraco
+  extend ActiveSupport::Concern
+
+  included do
+    DeepL.configure do |config|
+      config.auth_key = ENV.fetch("DEEPL_API_KEY", nil)
+      config.host = ENV.fetch("DEEPL_API_HOST", "https://api-free.deepl.com")
+    end
+  end
+
+  class_methods do
+    def auto_translates(*attributes)
+      attributes.each do |attribute|
+        define_method("#{attribute}=") do |val|
+          I18n.available_locales.each do |l|
+            return if send("#{attribute}_#{l}").present?
+
+            translated = ::DeepL.translate(val, I18n.locale, l).text
+            send("#{attribute}_#{l}=", translated)
+
+          rescue ::DeepL::Exceptions::RequestError, ::DeepL::Exceptions::NotSupported, DeepL::Exceptions::Error => e
+            Rails.logger.error("DeepL error: #{e.message}")
+            send("#{attribute}_#{l}=", val)
+          end
+
+          translate_slugs_if_new_record
+        end
+      end
+    end
+  end
+
+  def translate_slugs_if_new_record
+    return unless new_record?
+
+    current_locale = I18n.locale
+    I18n.available_locales.each do |l|
+      next if l == current_locale
+
+      I18n.with_locale(l) { set_slug }
+    end
+  end
+end

--- a/app/models/concerns/folio/deepl_for_traco.rb
+++ b/app/models/concerns/folio/deepl_for_traco.rb
@@ -2,7 +2,7 @@
 
 require "deepl"
 
-module Folio::AutoTranslateForTraco
+module Folio::DeeplForTraco
   extend ActiveSupport::Concern
 
   included do
@@ -10,6 +10,8 @@ module Folio::AutoTranslateForTraco
       config.auth_key = ENV.fetch("DEEPL_API_KEY", nil)
       config.host = ENV.fetch("DEEPL_API_HOST", "https://api-free.deepl.com")
     end
+
+    before_validation :translate_slugs_if_new_record
   end
 
   class_methods do
@@ -26,8 +28,6 @@ module Folio::AutoTranslateForTraco
             Rails.logger.error("DeepL error: #{e.message}")
             send("#{attribute}_#{l}=", val)
           end
-
-          translate_slugs_if_new_record
         end
       end
     end

--- a/app/models/concerns/folio/deepl_for_traco.rb
+++ b/app/models/concerns/folio/deepl_for_traco.rb
@@ -15,7 +15,7 @@ module Folio::DeeplForTraco
   end
 
   class_methods do
-    def auto_translates(*attributes)
+    def deepl_translates(*attributes)
       attributes.each do |attribute|
         define_method("#{attribute}=") do |val|
           I18n.available_locales.each do |l|

--- a/folio.gemspec
+++ b/folio.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency "coffee-rails", "~> 5.0"
   s.add_dependency "countries"
   s.add_dependency "country_select"
+  s.add_dependency "deepl-rb"
   s.add_dependency "devise_invitable"
   s.add_dependency "devise-bootstrap-views"
   s.add_dependency "devise-i18n"


### PR DESCRIPTION
Jednoduchá logika. Vyžaduje mít 
`include Folio::FriendlyIdForTraco`
pod to si dáš
`include Folio::AutoTranslateForTraco`
a `auto_translates :title`

Do formuláře dám místo translated_inputs normální input, na kontrolleru povolím parametr a pak už to za mě samo přeloží sloupečky včetně přeložení slugů.