### PR TITLE
Allow catalog sort to be disabled

### DIFF
--- a/app/cells/folio/console/catalogue_cell.rb
+++ b/app/cells/folio/console/catalogue_cell.rb
@@ -66,8 +66,9 @@ class Folio::Console::CatalogueCell < Folio::ConsoleCell
                                       skip_desktop_header:)
 
     if rendering_header?
+      allow_sorting = model.fetch(:allow_sorting, true)
       @header_html += content_tag(:div,
-                                  label_for(name, skip_desktop_header:, allow_sorting: true),
+                                  label_for(name, skip_desktop_header:, allow_sorting:),
                                   class: full_class_name,
                                   hidden: hidden ? "" : nil)
     else


### PR DESCRIPTION
Catalogue v Auctify používám při výpisu smluv, které se vážou ke konkrétnímu předmětu. 

`= catalogue(@contracts,
              klass: Auctify::Features::Contract::Base,
              allow_sorting: false)`

Smluv nebude tolik, aby je bylo potřeba řadit podle sloupců, a sort v tomto místě nefunguje, protože jsem pod `items_controller`, ne contracts.

![image](https://github.com/sinfin/folio/assets/57494154/828aac72-d2b1-470c-abac-ac962585bde4)
