### PR TITLE
cabaktom/add bootstrap tooltip to folio and folio console

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -718,6 +718,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/assets/javascripts/folio/base_tooltip_controller.js
+++ b/app/assets/javascripts/folio/base_tooltip_controller.js
@@ -1,0 +1,20 @@
+class BaseTooltipController extends window.Stimulus.Controller {
+  static values = {
+    title: String,
+    placement: { type: String, default: 'auto' },
+    trigger: { type: String, default: 'hover' },
+  }
+
+  connect () {
+    this.tooltip = new window.bootstrap.Tooltip(this.element, {
+      title: this.titleValue,
+      placement: this.placementValue,
+      trigger: this.triggerValue,
+    })
+  }
+
+  disconnect () {
+    this.tooltip.dispose()
+    delete this.tooltip
+  }
+}

--- a/app/assets/javascripts/folio/console/base.js
+++ b/app/assets/javascripts/folio/console/base.js
@@ -59,6 +59,7 @@
 //= require folio/console/modules/event_names
 //= require folio/console/modules/danger-box-shadow-blink
 //= require folio/console/modules/popover
+//= require folio/console/modules/tooltip
 //= require folio/console/modules/dirty-forms
 //= require folio/console/modules/with_aside
 //= require folio/console/modules/input/url

--- a/app/assets/javascripts/folio/console/modules/tooltip.js
+++ b/app/assets/javascripts/folio/console/modules/tooltip.js
@@ -1,20 +1,3 @@
-window.Folio.Stimulus.register('f-c-tooltip', class extends window.Stimulus.Controller {
-  static values = {
-    title: String,
-    placement: { type: String, default: 'auto' },
-    trigger: { type: String, default: 'hover' },
-  }
+//= require folio/base_tooltip_controller
 
-  connect () {
-    this.tooltip = new window.bootstrap.Tooltip(this.element, {
-      title: this.titleValue,
-      placement: this.placementValue,
-      trigger: this.triggerValue,
-    })
-  }
-
-  disconnect () {
-    this.tooltip.dispose()
-    delete this.tooltip
-  }
-})
+window.Folio.Stimulus.register('f-c-tooltip', class extends BaseTooltipController {});

--- a/app/assets/javascripts/folio/console/modules/tooltip.js
+++ b/app/assets/javascripts/folio/console/modules/tooltip.js
@@ -1,0 +1,20 @@
+window.Folio.Stimulus.register('f-c-tooltip', class extends window.Stimulus.Controller {
+  static values = {
+    title: String,
+    placement: { type: String, default: 'auto' },
+    trigger: { type: String, default: 'hover' },
+  }
+
+  connect () {
+    this.tooltip = new window.bootstrap.Tooltip(this.element, {
+      title: this.titleValue,
+      placement: this.placementValue,
+      trigger: this.triggerValue,
+    })
+  }
+
+  disconnect () {
+    this.tooltip.dispose()
+    delete this.tooltip
+  }
+})

--- a/app/assets/javascripts/folio/tooltip.js
+++ b/app/assets/javascripts/folio/tooltip.js
@@ -1,20 +1,3 @@
-window.Folio.Stimulus.register('f-tooltip', class extends window.Stimulus.Controller {
-  static values = {
-    title: String,
-    placement: { type: String, default: 'auto' },
-    trigger: { type: String, default: 'hover' },
-  }
+//= require folio/base_tooltip_controller
 
-  connect () {
-    this.tooltip = new window.bootstrap.Tooltip(this.element, {
-      title: this.titleValue,
-      placement: this.placementValue,
-      trigger: this.triggerValue,
-    })
-  }
-
-  disconnect () {
-    this.tooltip.dispose()
-    delete this.tooltip
-  }
-})
+window.Folio.Stimulus.register('f-tooltip', class extends BaseTooltipController {})

--- a/app/assets/javascripts/folio/tooltip.js
+++ b/app/assets/javascripts/folio/tooltip.js
@@ -1,0 +1,20 @@
+window.Folio.Stimulus.register('f-tooltip', class extends window.Stimulus.Controller {
+  static values = {
+    title: String,
+    placement: { type: String, default: 'auto' },
+    trigger: { type: String, default: 'hover' },
+  }
+
+  connect () {
+    this.tooltip = new window.bootstrap.Tooltip(this.element, {
+      title: this.titleValue,
+      placement: this.placementValue,
+      trigger: this.triggerValue,
+    })
+  }
+
+  disconnect () {
+    this.tooltip.dispose()
+    delete this.tooltip
+  }
+})

--- a/test/dummy/app/assets/stylesheets/_custom_bootstrap.sass
+++ b/test/dummy/app/assets/stylesheets/_custom_bootstrap.sass
@@ -40,7 +40,7 @@
 // @import "folio-bootstrap-5/scss/close"
 // @import "folio-bootstrap-5/scss/toasts"
 @import "folio-bootstrap-5/scss/modal"
-// @import "folio-bootstrap-5/scss/tooltip"
+@import "folio-bootstrap-5/scss/tooltip"
 // @import "folio-bootstrap-5/scss/popover"
 // @import "folio-bootstrap-5/scss/carousel"
 // @import "folio-bootstrap-5/scss/spinners"


### PR DESCRIPTION
Prerekvizita pro [Auctify PR # 566](https://github.com/sinfin/foliolized_auctify/pull/566) ‼️

Po vzoru [popover.js](https://github.com/sinfin/folio/blob/5b9c49afc05de0b1430c220afaca3e722355be5a/app/assets/javascripts/folio/console/modules/popover.js) jsem přidal tooltip do `folio/console` i do `folio`. Oba `tooltip.js` jsou teď stejné, ale přijde mi logické to takhle oddělit.

V console se to pak v libovolném componentu používá takto:
```
stimulus_controller("f-c-tooltip",
                        values: {
                          title:,
                          placement: "bottom",
                          trigger: "hover focus",
                        })
```
<img width="244" alt="image" src="https://github.com/sinfin/folio/assets/57494154/991a9aaf-397c-46fa-83e0-d5ffe1713671">

Pro funkčnost ve frontendu auctify je nutné přidat Bootstrap, viz. [Auctify PR # 566](https://github.com/sinfin/foliolized_auctify/pull/566)