### PR TITLE
users authorized per site

### DIFF
--- a/app/cells/folio/console/layout/header_cell.rb
+++ b/app/cells/folio/console/layout/header_cell.rb
@@ -8,7 +8,7 @@ class Folio::Console::Layout::HeaderCell < Folio::ConsoleCell
       if try(:current_user)
         opts = {
           only_path: false,
-          host: Folio.site_for_crossdomain_devise.try(:env_aware_domain)
+          host: Folio.enabled_site_for_crossdomain_devise.try(:env_aware_domain)
         }.compact
 
         router = controller

--- a/app/cells/folio/console/users/invite_and_copy_cell.rb
+++ b/app/cells/folio/console/users/invite_and_copy_cell.rb
@@ -7,8 +7,8 @@ class Folio::Console::Users::InviteAndCopyCell < Folio::ConsoleCell
       only_path: false,
     }
 
-    if ::Rails.application.config.folio_crossdomain_devise && Folio.site_for_crossdomain_devise
-      args[:host] = Folio.site_for_crossdomain_devise.env_aware_domain
+    if ::Rails.application.config.folio_crossdomain_devise && Folio.enabled_site_for_crossdomain_devise
+      args[:host] = Folio.enabled_site_for_crossdomain_devise.env_aware_domain
     end
 
     controller.accept_invitation_url(model, args)

--- a/app/controllers/concerns/folio/devise/crossdomain_controller.rb
+++ b/app/controllers/concerns/folio/devise/crossdomain_controller.rb
@@ -23,7 +23,7 @@ module Folio::Devise::CrossdomainController
                                                                           resource_name: safe_resource_name,
                                                                           action_name:,
                                                                           devise_controller: try(:devise_controller?),
-                                                                          master_site: Folio.site_for_crossdomain_devise,
+                                                                          master_site: Folio.enabled_site_for_crossdomain_devise,
                                                                           resource_class: Folio::User)
 
       result = @devise_crossdomain_handler.handle_before_action!
@@ -61,7 +61,8 @@ module Folio::Devise::CrossdomainController
     def authenticate_user!(*args)
       if Rails.application.config.folio_crossdomain_devise &&
          current_user.nil? &&
-         current_site != Folio.site_for_crossdomain_devise
+         current_site.present? &&
+         current_site != Folio.enabled_enabled_site_for_crossdomain_devise
         handle_crossdomain_devise
 
         result = @devise_crossdomain_handler.authenticate_user_on_slave_site!

--- a/app/controllers/concerns/folio/set_current_request_details.rb
+++ b/app/controllers/concerns/folio/set_current_request_details.rb
@@ -10,10 +10,14 @@ module Folio::SetCurrentRequestDetails
   private
     def set_up_current_from_request
       if Folio::Current.request_id.nil? || (request && request.uuid != Folio::Current.request_id)
-        Folio::Current.setup!(request:,
-                              site: Folio.current_site(request:, controller: self),
-                              user: current_user,
-                              session:)
+        site = Folio.current_site(request:, controller: self)
+
+        # warden takes params from request, so we need to set source_site_id here,
+        # before searching for current user
+        request.params["user"]["source_site_id"] = site.id.to_s if request.params["user"].present?
+        user = current_user
+
+        Folio::Current.setup!(request:, site:, user:, session:)
       end
     end
 end

--- a/app/controllers/concerns/folio/set_current_request_details.rb
+++ b/app/controllers/concerns/folio/set_current_request_details.rb
@@ -14,7 +14,9 @@ module Folio::SetCurrentRequestDetails
 
         # warden takes params from request, so we need to set source_site_id here,
         # before searching for current user
-        request.params["user"]["source_site_id"] = site.id.to_s if request.params["user"].present?
+        if request.params["user"].present? && request.params["user"]["auth_site_id"].blank?
+          request.params["user"]["auth_site_id"] = site.id.to_s
+        end
         user = current_user
 
         Folio::Current.setup!(request:, site:, user:, session:)

--- a/app/controllers/concerns/folio/users/devise_controller_base.rb
+++ b/app/controllers/concerns/folio/users/devise_controller_base.rb
@@ -63,7 +63,7 @@ module Folio::Users::DeviseControllerBase
   private
     def add_auth_site_id_to_params
       if request.params["user"]
-        request.params["user"]["auth_site_id"] = (::Folio.site_for_crossdomain_devise || current_site).id.to_s
+        request.params["user"]["auth_site_id"] = (::Folio.enabled_site_for_crossdomain_devise || current_site).id.to_s
       end
     end
 

--- a/app/controllers/concerns/folio/users/devise_controller_base.rb
+++ b/app/controllers/concerns/folio/users/devise_controller_base.rb
@@ -4,6 +4,10 @@ module Folio::Users::DeviseControllerBase
   extend ActiveSupport::Concern
   include Folio::Devise::CrossdomainController
 
+  included do
+    before_action :add_source_site_id_to_params
+  end
+
   def after_sign_in_path_for(_resource)
     stored_location_for(:user) ||
     main_app.send(Rails.application.config.folio_users_after_sign_in_path)
@@ -57,6 +61,10 @@ module Folio::Users::DeviseControllerBase
   end
 
   private
+    def add_source_site_id_to_params
+      request.params["user"]["source_site_id"] = current_site.id.to_s if request.params["user"]
+    end
+
     def safe_set_up_current_from_request
       if respond_to?(:set_up_current_from_request, true)
         set_up_current_from_request

--- a/app/controllers/concerns/folio/users/devise_controller_base.rb
+++ b/app/controllers/concerns/folio/users/devise_controller_base.rb
@@ -5,7 +5,7 @@ module Folio::Users::DeviseControllerBase
   include Folio::Devise::CrossdomainController
 
   included do
-    before_action :add_source_site_id_to_params
+    before_action :add_auth_site_id_to_params
   end
 
   def after_sign_in_path_for(_resource)
@@ -61,8 +61,10 @@ module Folio::Users::DeviseControllerBase
   end
 
   private
-    def add_source_site_id_to_params
-      request.params["user"]["source_site_id"] = current_site.id.to_s if request.params["user"]
+    def add_auth_site_id_to_params
+      if request.params["user"]
+        request.params["user"]["auth_site_id"] = (::Folio.site_for_crossdomain_devise || current_site).id.to_s
+      end
     end
 
     def safe_set_up_current_from_request

--- a/app/controllers/folio/users/invitations_controller.rb
+++ b/app/controllers/folio/users/invitations_controller.rb
@@ -8,12 +8,12 @@ class Folio::Users::InvitationsController < Devise::InvitationsController
 
 
   def new
-    if Rails.application.config.folio_crossdomain_devise && current_site != ::Folio.site_for_crossdomain_devise
+    if Rails.application.config.folio_crossdomain_devise && current_site != ::Folio.enabled_site_for_crossdomain_devise
       session[Folio::Devise::CrossdomainHandler::SESSION_KEY] ||= {}
       session[Folio::Devise::CrossdomainHandler::SESSION_KEY][:target_site_slug] = current_site.slug
 
       redirect_to new_user_invitation_url(only_path: false,
-                                          host: ::Folio.site_for_crossdomain_devise.env_aware_domain),
+                                          host: ::Folio.enabled_site_for_crossdomain_devise.env_aware_domain),
                   allow_other_host: true
     else
       super
@@ -147,7 +147,7 @@ class Folio::Users::InvitationsController < Devise::InvitationsController
 
       if resource.nil? && current_user
         set_flash_message(:alert, "already_authenticated", scope: "devise.failure")
-        redirect_to after_sign_in_path_for(resource)
+        redirect_to after_sign_in_path_for(current_user)
       end
     end
 end

--- a/app/controllers/folio/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/folio/users/omniauth_callbacks_controller.rb
@@ -183,6 +183,7 @@ class Folio::Users::OmniauthCallbacksController < Devise::OmniauthCallbacksContr
     def create_user_params
       params.require(:user)
             .permit(:email,
+                    :auth_site_id,
                     *Folio::User.controller_strong_params_for_create)
     end
 

--- a/app/lib/folio/devise/crossdomain_handler.rb
+++ b/app/lib/folio/devise/crossdomain_handler.rb
@@ -37,7 +37,7 @@ class Folio::Devise::CrossdomainHandler
     @controller_name = controller_name
     @action_name = action_name
     @params = params || {}
-    @master_site = master_site || Folio.site_for_crossdomain_devise
+    @master_site = master_site || Folio.enabled_site_for_crossdomain_devise
     @resource_class = resource_class || Folio::User
     @resource_name = resource_name || :user
     @devise_controller = devise_controller

--- a/app/mailers/folio/devise_mailer.rb
+++ b/app/mailers/folio/devise_mailer.rb
@@ -82,10 +82,10 @@ class Folio::DeviseMailer < Devise::Mailer
         method.to_s.gsub(/\A([a-z]+)_/, "\\1_#{scoped}_")
       end
 
-      if Rails.application.config.folio_crossdomain_devise && Folio.site_for_crossdomain_devise
+      if Folio.enabled_site_for_crossdomain_devise
         extra = {
           only_path: false,
-          host: Folio.site_for_crossdomain_devise.env_aware_domain,
+          host: Folio.enabled_site_for_crossdomain_devise.env_aware_domain,
           protocol: (Rails.env.development? && !ENV["FORCE_SSL"]) ? "http" : "https"
         }
 

--- a/app/models/concerns/folio/has_sanitized_fields.rb
+++ b/app/models/concerns/folio/has_sanitized_fields.rb
@@ -5,7 +5,7 @@ module Folio::HasSanitizedFields
 
   class_methods do
     def has_sanitized_fields(*fields)
-      before_save :sanitize_fields
+      before_validation :sanitize_fields
 
       define_singleton_method :fields_to_sanitize do
         fields

--- a/app/models/folio/site.rb
+++ b/app/models/folio/site.rb
@@ -27,6 +27,11 @@ class Folio::Site < Folio::ApplicationRecord
                           foreign_key: :source_site_id,
                           inverse_of: :source_site,
                           dependent: :nullify
+  has_many :auth_users, class_name: "Folio::User",
+                        foreign_key: :auth_site_id,
+                        inverse_of: :auth_site,
+                        dependent: :destroy
+
   has_many :site_user_links, class_name: "Folio::SiteUserLink",
                              foreign_key: :site_id,
                              inverse_of: :site,

--- a/app/models/folio/user.rb
+++ b/app/models/folio/user.rb
@@ -329,7 +329,13 @@ class Folio::User < Folio::ApplicationRecord
     def self.find_for_authentication(warden_params)
       email = warden_params[:email]
       site = ::Folio.site_for_crossdomain_devise || ::Folio::Site.find(warden_params[:auth_site_id])
-      site.auth_users.find_by(email:)
+
+      user = site.auth_users.find_by(email:)
+      if user.nil? && Folio.main_site.present? && site != Folio.main_site
+        # user = Folio::User.superadmins.find_by(email:)
+        user = Folio.main_site.auth_users.superadmins.find_by(email:)
+      end
+      user
     end
 
     def validate_names?

--- a/app/models/folio/user.rb
+++ b/app/models/folio/user.rb
@@ -65,8 +65,8 @@ class Folio::User < Folio::ApplicationRecord
   validate :validate_one_of_names
 
   validates :email,
-            format: { with: Folio::EMAIL_REGEXP },
-            if: :email?
+            uniqueness: { scope: :source_site, case_sensitive: false },
+            format: { with: Folio::EMAIL_REGEXP }
 
   validates :phone,
             phone: true,
@@ -323,6 +323,13 @@ class Folio::User < Folio::ApplicationRecord
   end
 
   private
+    # Override of Devise method to scope authentication by zone.
+    def self.find_for_authentication(warden_params)
+      email = warden_params[:email]
+      site = ::Folio::Site.find(warden_params[:source_site_id])
+      site.source_users.find_by(email:)
+    end
+
     def validate_names?
       invitation_accepted_at?
     end

--- a/app/models/folio/user.rb
+++ b/app/models/folio/user.rb
@@ -328,7 +328,7 @@ class Folio::User < Folio::ApplicationRecord
     # Override of Devise method to scope authentication by zone.
     def self.find_for_authentication(warden_params)
       email = warden_params[:email]
-      site = ::Folio.site_for_crossdomain_devise || ::Folio::Site.find(warden_params[:auth_site_id])
+      site = ::Folio.enabled_site_for_crossdomain_devise || ::Folio::Site.find(warden_params[:auth_site_id])
 
       user = site.auth_users.find_by(email:)
       if user.nil? && Folio.main_site.present? && site != Folio.main_site

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -52,7 +52,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  config.authentication_keys = [:email, :source_site_id]
+  config.authentication_keys = [:email, :auth_site_id]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -152,7 +152,7 @@ Devise.setup do |config|
 
   # The key to be used to check existing users when sending an invitation
   # and the regexp used to test it when validate_on_invite is not set.
-  config.invite_key = { email: URI::MailTo::EMAIL_REGEXP, source_site_id: ->(id) { id.to_s.match(/\A\d+\z/) } }
+  config.invite_key = { email: URI::MailTo::EMAIL_REGEXP, auth_site_id: ->(id) { id.to_s.match(/\A\d+\z/) } }
   # config.invite_key = { email: /\A[^@]+@[^@]+\z/, username: nil }
 
   # Ensure that invited record is valid.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -52,7 +52,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:email, :source_site_id]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -152,7 +152,7 @@ Devise.setup do |config|
 
   # The key to be used to check existing users when sending an invitation
   # and the regexp used to test it when validate_on_invite is not set.
-  # config.invite_key = { email: /\A[^@]+@[^@]+\z/ }
+  config.invite_key = { email: URI::MailTo::EMAIL_REGEXP, source_site_id: ->(id) { id.to_s.match(/\A\d+\z/) } }
   # config.invite_key = { email: /\A[^@]+@[^@]+\z/, username: nil }
 
   # Ensure that invited record is valid.

--- a/db/migrate/20240808152708_add_auth_site_to_folio_users.rb
+++ b/db/migrate/20240808152708_add_auth_site_to_folio_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAuthSiteToFolioUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :folio_users, :auth_site, null: false, foreign_key: { to_table: :folio_sites }, default: Folio.main_site.id
+  end
+end

--- a/lib/folio.rb
+++ b/lib/folio.rb
@@ -55,7 +55,7 @@ module Folio
     en_US: "US"
   }
 
-  EMAIL_REGEXP = Devise.email_regexp
+  EMAIL_REGEXP = URI::MailTo::EMAIL_REGEXP # Devise.email_regexp
   OG_IMAGE_DIMENSIONS = "1200x630#"
 
   # respect app/assets/javascripts/folio/message_bus.js

--- a/lib/folio.rb
+++ b/lib/folio.rb
@@ -82,7 +82,10 @@ module Folio
     Folio.main_site
   end
 
-  # set to force authentication via a site
+  def self.enabled_site_for_crossdomain_devise
+    Rails.application.config.folio_crossdomain_devise ? site_for_crossdomain_devise : nil
+  end
+
   def self.site_for_crossdomain_devise
     nil
   end

--- a/test/controllers/folio/devise/sessions_controller_test.rb
+++ b/test/controllers/folio/devise/sessions_controller_test.rb
@@ -33,8 +33,6 @@ class Folio::Devise::SessionsControllerTest < ActionDispatch::IntegrationTest
     site2 = create(:folio_site, domain: "site2.localhost", type: "Folio::Site")
     main_site = create(:folio_site, domain: "main.localhost", type: "Folio::Site")
     email = "superadmin@kocourek.cz"
-    user_site1 = user_site2 = nil
-
     _superadmin = create(:folio_user, email:, password: "password1", superadmin: true, auth_site: main_site)
 
     Rails.application.config.stub(:folio_crossdomain_devise, false) do

--- a/test/controllers/folio/devise/sessions_controller_test.rb
+++ b/test/controllers/folio/devise/sessions_controller_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Folio::Devise::SessionsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test "create (sign_in) without crossdomain => two users" do
+    site1 = create(:folio_site, domain: "site1.localhost", type: "Folio::Site")
+    site2 = create(:folio_site, domain: "site2.localhost", type: "Folio::Site")
+    email = "franta@kocourek.cz"
+    user_site1 = user_site2 = nil
+
+    assert ::Folio.site_for_crossdomain_devise.nil?
+    assert_nil ::Folio.main_site
+
+    assert_difference("::Folio::User.count", 2) do
+      user_site1 = register_user_at_site(site1, email:, first_name: "Site1", last_name: "User", password: "password1")
+      user_site2 = register_user_at_site(site2, email:, first_name: "Site2", last_name: "User", password: "password2")
+    end
+
+    assert_not_equal user_site1, user_site2
+    assert_not_equal user_site1.source_site, user_site2.source_site
+
+    # let try to sign in to sites
+    assert can_sign_in_at_site?(site1, email:, password: "password1")
+    assert_not can_sign_in_at_site?(site1, email:, password: "password2")
+    assert_not can_sign_in_at_site?(site2, email:, password: "password1")
+    assert can_sign_in_at_site?(site2, email:, password: "password2")
+  end
+
+
+
+  private
+    def register_user_at_site(site, email:, first_name:, last_name:, password:)
+      host_site site
+
+      user_site = nil
+
+      Rails.application.config.stub(:folio_users_publicly_invitable, true) do
+        get new_user_invitation_url(only_path: false, host: site.env_aware_domain)
+
+        assert_response :success
+
+        post user_invitation_url(only_path: false,
+                                  host: site.env_aware_domain),
+                                  params: { user: { email: } }
+
+        assert_redirected_to user_invitation_url(only_path: false, host: site.env_aware_domain)
+        follow_redirect!
+        # File.write("response.html", response.body)
+
+        user_site = ::Folio::User.where(source_site: site, email:).first
+        user_site.update(first_name:, last_name:, password:, password_confirmation: password)
+        user_site.accept_invitation!
+
+        assert user_site.reload.invitation_accepted?
+      end
+      user_site
+    end
+
+    def can_sign_in_at_site?(site, email:, password:)
+      host_site site
+      puts("Trying to sign in at #{site.env_aware_domain} with #{email} and #{password}")
+      post user_session_url(only_path: false, host: site.env_aware_domain),
+           params: { user: { email:, password: } }
+
+      # not signed in?
+      return false if response.redirect? && response.location == user_session_url(only_path: false, host: site.env_aware_domain)
+
+      follow_redirect!
+      assert_response :success
+
+      get destroy_user_session_url(only_path: false, host: site.env_aware_domain)
+      true
+    rescue StandardError
+      false
+    end
+end

--- a/test/controllers/folio/devise/sessions_controller_test.rb
+++ b/test/controllers/folio/devise/sessions_controller_test.rb
@@ -28,6 +28,26 @@ class Folio::Devise::SessionsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "create (sign_in) without crossdomain superadmin have one account on main site for all sites" do
+    site1 = create(:folio_site, domain: "site1.localhost", type: "Folio::Site")
+    site2 = create(:folio_site, domain: "site2.localhost", type: "Folio::Site")
+    main_site = create(:folio_site, domain: "main.localhost", type: "Folio::Site")
+    email = "superadmin@kocourek.cz"
+    user_site1 = user_site2 = nil
+
+    _superadmin = create(:folio_user, email:, password: "password1", superadmin: true, auth_site: main_site)
+
+    Rails.application.config.stub(:folio_crossdomain_devise, false) do
+      Folio.stub(:main_site, main_site) do
+        # let try to sign in to sites
+        assert can_sign_in_at_site?(main_site, email:, password: "password1")
+        assert can_sign_in_at_site?(site1, email:, password: "password1")
+        assert can_sign_in_at_site?(site2, email:, password: "password1")
+      end
+    end
+  end
+
+
   test "create (sign_in) with crossdomain => one user" do
     site1 = create(:folio_site, domain: "site1.localhost", type: "Folio::Site")
     site2 = create(:folio_site, domain: "site2.localhost", type: "Folio::Site")

--- a/test/controllers/folio/devise/sessions_controller_test.rb
+++ b/test/controllers/folio/devise/sessions_controller_test.rb
@@ -11,24 +11,48 @@ class Folio::Devise::SessionsControllerTest < ActionDispatch::IntegrationTest
     email = "franta@kocourek.cz"
     user_site1 = user_site2 = nil
 
-    assert ::Folio.site_for_crossdomain_devise.nil?
-    assert_nil ::Folio.main_site
+    Rails.application.config.stub(:folio_crossdomain_devise, false) do
+      assert_difference("::Folio::User.count", 2) do
+        user_site1 = register_user_at_site(site1, email:, first_name: "Site1", last_name: "User", password: "password1")
+        user_site2 = register_user_at_site(site2, email:, first_name: "Site2", last_name: "User", password: "password2")
+      end
 
-    assert_difference("::Folio::User.count", 2) do
-      user_site1 = register_user_at_site(site1, email:, first_name: "Site1", last_name: "User", password: "password1")
-      user_site2 = register_user_at_site(site2, email:, first_name: "Site2", last_name: "User", password: "password2")
+      assert_not_equal user_site1, user_site2
+      assert_not_equal user_site1.auth_site, user_site2.auth_site
+
+      # let try to sign in to sites
+      assert can_sign_in_at_site?(site1, email:, password: "password1")
+      assert_not can_sign_in_at_site?(site1, email:, password: "password2")
+      assert_not can_sign_in_at_site?(site2, email:, password: "password1")
+      assert can_sign_in_at_site?(site2, email:, password: "password2")
     end
-
-    assert_not_equal user_site1, user_site2
-    assert_not_equal user_site1.source_site, user_site2.source_site
-
-    # let try to sign in to sites
-    assert can_sign_in_at_site?(site1, email:, password: "password1")
-    assert_not can_sign_in_at_site?(site1, email:, password: "password2")
-    assert_not can_sign_in_at_site?(site2, email:, password: "password1")
-    assert can_sign_in_at_site?(site2, email:, password: "password2")
   end
 
+  test "create (sign_in) with crossdomain => one user" do
+    site1 = create(:folio_site, domain: "site1.localhost", type: "Folio::Site")
+    site2 = create(:folio_site, domain: "site2.localhost", type: "Folio::Site")
+    xdomain_site = create(:folio_site, domain: "xdomain.localhost", type: "Folio::Site")
+    email = "franta@kocourek.cz"
+    user_site1 = user_site2 = nil
+
+    Rails.application.config.stub(:folio_crossdomain_devise, true) do
+      ::Folio.stub(:site_for_crossdomain_devise, xdomain_site) do
+        # assert_difference("::Folio::User.count", 1) do
+        user_site1 = register_user_through_xdomain_site(site1, email:, first_name: "Site1", last_name: "User", password: "password1")
+        user_site2 = register_user_through_xdomain_site(site2, email:, first_name: "Site2", last_name: "User", password: "password2")
+        # end
+
+        assert_equal user_site1, user_site2
+        assert_equal ::Folio.site_for_crossdomain_devise, user_site1.auth_site
+
+        # let try to sign in to sites ("password2" is invalid)
+        assert can_sign_in_at_site?(site1, email:, password: "password1")
+        assert_not can_sign_in_at_site?(site1, email:, password: "password2")
+        assert can_sign_in_at_site?(site2, email:, password: "password1")
+        assert_not can_sign_in_at_site?(site2, email:, password: "password2")
+      end
+    end
+  end
 
 
   private
@@ -48,9 +72,8 @@ class Folio::Devise::SessionsControllerTest < ActionDispatch::IntegrationTest
 
         assert_redirected_to user_invitation_url(only_path: false, host: site.env_aware_domain)
         follow_redirect!
-        # File.write("response.html", response.body)
 
-        user_site = ::Folio::User.where(source_site: site, email:).first
+        user_site = ::Folio::User.where(auth_site: site, email:).first
         user_site.update(first_name:, last_name:, password:, password_confirmation: password)
         user_site.accept_invitation!
 
@@ -59,14 +82,58 @@ class Folio::Devise::SessionsControllerTest < ActionDispatch::IntegrationTest
       user_site
     end
 
+    def register_user_through_xdomain_site(auth_site, email:, first_name:, last_name:, password:)
+      host_site auth_site
+
+      xdomain_site = ::Folio.site_for_crossdomain_devise
+      user_site = ::Folio::User.where(auth_site: xdomain_site, email:).first
+
+      Rails.application.config.stub(:folio_users_publicly_invitable, true) do
+        get new_user_invitation_url(only_path: false, host: site.env_aware_domain)
+
+        assert response.redirect?
+        uri = URI.parse(response.location)
+        assert_equal xdomain_site.env_aware_domain, uri.host
+        assert_equal new_user_invitation_path, uri.path
+        assert uri.query.include?("crossdomain=")
+
+        follow_redirect!
+        assert_response :success
+
+        post user_invitation_url(only_path: false,
+                                  host: xdomain_site.env_aware_domain),
+                                  params: { user: { email: } }
+
+        if user_site.present? # already registered
+          if user_site.invitation_accepted?
+            assert_response :unprocessable_entity
+            assert response.body.include?('<div class="invalid-feedback">E-mail již databáze obsahuje</div>')
+          else
+            assert_redirected_to user_invitation_url(only_path: false, host: xdomain_site.env_aware_domain)
+            follow_redirect!
+          end
+        else # totaly new user
+          assert_redirected_to user_invitation_url(only_path: false, host: xdomain_site.env_aware_domain)
+          follow_redirect!
+
+          user_site = ::Folio::User.where(auth_site: xdomain_site, email:).first
+          user_site.update(first_name:, last_name:, password:, password_confirmation: password)
+          user_site.accept_invitation!
+
+          assert user_site.reload.invitation_accepted?
+        end
+      end
+      user_site
+    end
+
     def can_sign_in_at_site?(site, email:, password:)
       host_site site
-      puts("Trying to sign in at #{site.env_aware_domain} with #{email} and #{password}")
+
       post user_session_url(only_path: false, host: site.env_aware_domain),
            params: { user: { email:, password: } }
 
       # not signed in?
-      return false if response.redirect? && response.location == user_session_url(only_path: false, host: site.env_aware_domain)
+      return false if response.redirect? && response.location.include?(new_user_session_path)
 
       follow_redirect!
       assert_response :success

--- a/test/controllers/folio/users/invitations_controller_test.rb
+++ b/test/controllers/folio/users/invitations_controller_test.rb
@@ -48,7 +48,7 @@ class Folio::Users::InvitationsControllerTest < ActionDispatch::IntegrationTest
 
   test "edit" do
     create_and_host_site
-    user = Folio::User.invite!(email: "email@email.email", source_site_id: @site.id)
+    user = Folio::User.invite!(email: "email@email.email", auth_site_id: @site.id)
     get main_app.accept_user_invitation_path(invitation_token: user.raw_invitation_token)
     assert_response(:ok)
   end
@@ -59,7 +59,7 @@ class Folio::Users::InvitationsControllerTest < ActionDispatch::IntegrationTest
     user = Folio::User.invite!(email: "email@email.email",
                                first_name: "a",
                                last_name: "b",
-                               source_site_id: @site.id)
+                               auth_site_id: @site.id)
     assert_not user.invitation_accepted?
 
     put main_app.user_invitation_path, params: {

--- a/test/controllers/folio/users/invitations_controller_test.rb
+++ b/test/controllers/folio/users/invitations_controller_test.rb
@@ -48,7 +48,7 @@ class Folio::Users::InvitationsControllerTest < ActionDispatch::IntegrationTest
 
   test "edit" do
     create_and_host_site
-    user = Folio::User.invite!(email: "email@email.email")
+    user = Folio::User.invite!(email: "email@email.email", source_site_id: @site.id)
     get main_app.accept_user_invitation_path(invitation_token: user.raw_invitation_token)
     assert_response(:ok)
   end
@@ -58,7 +58,8 @@ class Folio::Users::InvitationsControllerTest < ActionDispatch::IntegrationTest
 
     user = Folio::User.invite!(email: "email@email.email",
                                first_name: "a",
-                               last_name: "b")
+                               last_name: "b",
+                               source_site_id: @site.id)
     assert_not user.invitation_accepted?
 
     put main_app.user_invitation_path, params: {

--- a/test/controllers/folio/users/sessions_controller_test.rb
+++ b/test/controllers/folio/users/sessions_controller_test.rb
@@ -32,7 +32,7 @@ class Folio::Users::SessionsControllerTest < Folio::BaseControllerTest
 
   test "create pending invitation" do
     skip unless Rails.application.config.folio_users_publicly_invitable
-    user = Folio::User.invite!(email: "invite@email.email")
+    user = Folio::User.invite!(email: "invite@email.email", auth_site_id: ::Folio::Current.site.id)
     old_timestamp = user.invitation_created_at
     post main_app.user_session_path, params: { user: { email: "invite@email.email" } }
     assert_redirected_to user_invitation_path
@@ -41,7 +41,7 @@ class Folio::Users::SessionsControllerTest < Folio::BaseControllerTest
 
   test "ajax create pending invitation" do
     skip unless Rails.application.config.folio_users_publicly_invitable
-    user = Folio::User.invite!(email: "invite@email.email")
+    user = Folio::User.invite!(email: "invite@email.email", auth_site_id: ::Folio::Current.site.id)
     old_timestamp = user.invitation_created_at
     post main_app.user_session_path(format: :json), params: { user: { email: "invite@email.email" } }
     assert_response(:ok)

--- a/test/controllers/folio/users/sessions_controller_test.rb
+++ b/test/controllers/folio/users/sessions_controller_test.rb
@@ -22,7 +22,8 @@ class Folio::Users::SessionsControllerTest < Folio::BaseControllerTest
 
   test "create" do
     post main_app.user_session_path, params: { user: @params }
-    assert_redirected_to main_app.send(Rails.application.config.folio_users_after_sign_in_path)
+
+    assert_redirected_to controller.after_sign_in_path_for(@user)
   end
 
   test "ajax create" do

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -52,7 +52,10 @@ Rails.application.configure do
     Rack::MiniProfiler.config.skip_paths << "/rails/mailers/dummy/developer_mailer/debug"
   end
 
-  config.action_mailer.default_url_options = { host: "localhost", port: ENV["PORT"].presence || 3000, protocol: "http" }
+  config.action_mailer.default_url_options = { host: "localhost",
+                                               port: ENV["PORT"].presence || 3000,
+                                               protocol: "http",
+                                               locale: :cs }
 
   if ENV["DEV_QUEUE_ADAPTER"].present?
     config.active_job.queue_adapter = ENV["DEV_QUEUE_ADAPTER"]

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -37,7 +37,8 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
-  config.action_mailer.default_url_options = { host: "http://localhost:3000" }
+  config.action_mailer.default_url_options = { host: "http://localhost:3000",
+                                               locale: :cs }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/test/dummy/config/initializers/folio.rb
+++ b/test/dummy/config/initializers/folio.rb
@@ -3,5 +3,5 @@
 Rails.application.config.folio_users_confirmable = false
 Rails.application.config.folio_pages_audited = true
 Rails.application.config.folio_pages_ancestry = !Rails.env.test?
-
+Rails.application.config.folio_users_publicly_invitable = true # to make more test run
 Rails.application.config.folio_shared_files_between_sites = true

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_01_093103) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_08_152708) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -514,6 +514,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_01_093103) do
     t.string "bank_account_number"
     t.string "company_name"
     t.string "time_zone", default: "Prague"
+    t.bigint "auth_site_id", default: 1, null: false
+    t.index ["auth_site_id"], name: "index_folio_users_on_auth_site_id"
     t.index ["confirmation_token"], name: "index_folio_users_on_confirmation_token", unique: true
     t.index ["crossdomain_devise_token"], name: "index_folio_users_on_crossdomain_devise_token"
     t.index ["email"], name: "index_folio_users_on_email"
@@ -580,4 +582,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_01_093103) do
   add_foreign_key "folio_files", "folio_sites", column: "site_id"
   add_foreign_key "folio_site_user_links", "folio_sites", column: "site_id"
   add_foreign_key "folio_site_user_links", "folio_users", column: "user_id"
+  add_foreign_key "folio_users", "folio_sites", column: "auth_site_id"
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -143,6 +143,7 @@ FactoryBot.define do
     phone { "+420604123123" }
     superadmin { false }
     association(:primary_address, factory: :folio_address_primary)
+    source_site { get_current_or_existing_site_or_create_from_factory }
 
     trait :superadmin do
       superadmin { true }

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 def get_current_or_existing_site_or_create_from_factory
-  Folio::Current.site&.reload || Folio::Site.last || create(Rails.application.config.folio_site_default_test_factory)
+  site = begin
+    Folio::Current.site&.reload
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+  site || Folio::Site.last || create(Rails.application.config.folio_site_default_test_factory)
 end
 
 FactoryBot.define do

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 def get_current_or_existing_site_or_create_from_factory
-  Folio::Current.site || Folio::Site.last || create(Rails.application.config.folio_site_default_test_factory)
+  Folio::Current.site&.reload || Folio::Site.last || create(Rails.application.config.folio_site_default_test_factory)
 end
 
 FactoryBot.define do

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -143,7 +143,7 @@ FactoryBot.define do
     phone { "+420604123123" }
     superadmin { false }
     association(:primary_address, factory: :folio_address_primary)
-    source_site { get_current_or_existing_site_or_create_from_factory }
+    auth_site { get_current_or_existing_site_or_create_from_factory }
 
     trait :superadmin do
       superadmin { true }

--- a/test/integration/folio/console/shared_files_test.rb
+++ b/test/integration/folio/console/shared_files_test.rb
@@ -10,7 +10,7 @@ class Folio::SharedFilesTest < Folio::Console::BaseControllerTest
     @main_site = create_site(attributes: { domain: "sinfin.localhost" })
     @site_lvh = create_site(attributes: { domain: "lvh.me", locale: "en" }, force: true)
     Folio.instance_variable_set(:@main_site, nil) # to clear the cached version from other tests
-    @superadmin = create(:folio_user, :superadmin)
+    @superadmin = create(:folio_user, :superadmin, auth_site: main_site)
 
     @lvh_image = create(:folio_file_image, site: site_lvh)
     @shared_image = create(:folio_file_image, :black, site: main_site)

--- a/test/integration/folio/user_flow_test.rb
+++ b/test/integration/folio/user_flow_test.rb
@@ -30,7 +30,7 @@ class Folio::UserFlowTest < Folio::CapybaraTest
     assert_equal [], site_link.roles
 
     # clicks the e-mail with the accept link
-    user = Folio::User.invite!(email: "test@test.test")
+    user = Folio::User.invite!(email: "test@test.test", auth_site_id: @site.id)
     visit main_app.accept_user_invitation_url(invitation_token: user.raw_invitation_token)
 
     page.find('.f-devise--invitations-edit input[name="user[password]"]').set "Complex@Password.123"
@@ -76,8 +76,9 @@ class Folio::UserFlowTest < Folio::CapybaraTest
     # assert_redirected_to main_app.users_auth_new_user_path
     # follow_redirect! # asking user to create an account, serving data from Facebook
     page.has_css?("h1", text: "Dokončení registrace")
-    within(".f-devise-resource-form .user_email") do
-      page.has_css?("label", text: "E-mail (slouží pro přihlášení) ")
+
+    within(".f-devise-resource-form .f-devise-email-input") do
+      page.has_css?("label", text: "E-mail ")
       assert_equal OMNIAUTH_AUTHENTICATION_DEFAULT_TEST_EMAIL, find_field("user[email]").value
     end
 

--- a/test/integration/folio/user_flow_test.rb
+++ b/test/integration/folio/user_flow_test.rb
@@ -105,7 +105,7 @@ class Folio::UserFlowTest < Folio::CapybaraTest
 
     email = "folio@folio.com"
     password = "Complex@Password.123"
-    user = create(:folio_user, email:, password:)
+    user = create(:folio_user, email:, password:, auth_site_id: main_site.id)
     assert user.site_user_links.blank?
 
     Rails.application.config.stub(:folio_crossdomain_devise, true) do

--- a/test/models/concerns/folio/has_site_roles_test.rb
+++ b/test/models/concerns/folio/has_site_roles_test.rb
@@ -92,6 +92,7 @@ class Folio::HasSiteRolesTest < ActiveSupport::TestCase
     params = {
       "email" => "test@test.com",
       "password" => "test1234",
+      "auth_site_id" => site.id,
       "site_user_links_attributes" => { "0" => { "site_id" => site.id, "roles" => [] } }
     }
     user = Folio::User.new(params)

--- a/test/models/folio/user_test.rb
+++ b/test/models/folio/user_test.rb
@@ -12,6 +12,7 @@ class Folio::UserTest < ActiveSupport::TestCase
       user = Folio::User.invite!(email: "email-#{i}@email.email",
                                  first_name: "John",
                                  last_name: "Doe",
+                                 auth_site_id: subscribable_sites.first.id,
                                  subscribed_to_newsletter:) do |u|
         u.skip_invitation = true
       end

--- a/test/support/sites_helper.rb
+++ b/test/support/sites_helper.rb
@@ -9,7 +9,6 @@ module SitesHelper
     def create_and_host_site(key: nil, attributes: {}, force: false)
       site = create_site(key:, attributes:, force:)
       host_site(site)
-      Folio::Current.site = site
 
       site
     end
@@ -28,6 +27,7 @@ module SitesHelper
     def host_site(site)
       Rails.application.routes.default_url_options[:host] = site.domain
       Rails.application.routes.default_url_options[:only_path] = false
+      Folio::Current.site = site
 
       if self.respond_to?(:host!)
         host!(site.domain)

--- a/test/test_helper_base.rb
+++ b/test/test_helper_base.rb
@@ -112,7 +112,7 @@ class Folio::BaseControllerTest < ActionDispatch::IntegrationTest
 
   def setup
     super
-    @site = create_site() if @site.nil?
+    @site = create_site() if @site&.reload.nil?
     host_site(@site)
 
     @superadmin = create(:folio_user, :superadmin)


### PR DESCRIPTION
required for https://github.com/sinfin/foliolized_auctify/issues/678

If `Rails.application.config.folio_crossdomain_devise == true`  users are created with `user.auth_site == Folio.site_for_crossdomain_devise` and only one user for email address is allowed.

If `Rails.application.config.folio_crossdomain_devise == false` (default) users are created for each site ( `user.auth_site == current_site`) and there can be one user for email address AND site.