### PR TITLE
cabaktom/form modal redirect with anchor

### DIFF
--- a/app/assets/javascripts/folio/api.js
+++ b/app/assets/javascripts/folio/api.js
@@ -81,7 +81,24 @@ function responseToJson (response) {
 
 function responseToHtml (response) {
   if (response.status === 204) return Promise.resolve('')
-  if (response.redirected) return Promise.resolve('{ "data": { "redirected": true }}')
+
+  if (response.redirected) {
+    if (response.url) {
+      const urlObj = new URL(response.url)
+      const queryParams = urlObj.searchParams
+      const anchor = queryParams.get("_anchor")
+
+      if (anchor) {
+        queryParams.delete("_anchor")
+        urlObj.search = queryParams.toString()
+        return Promise.resolve(`{ "data": { "redirected": "${urlObj}#${anchor}" }}`)
+      }
+
+      return Promise.resolve(`{ "data": { "redirected": "${response.url}" }}`)
+    }
+    
+    return Promise.resolve('{ "data": { "redirected": true }}')
+  }
   return response.text()
 }
 

--- a/app/components/folio/console/form_modal_component.js
+++ b/app/components/folio/console/form_modal_component.js
@@ -74,8 +74,9 @@ window.Folio.Stimulus.register('f-c-form-modal', class extends window.Stimulus.C
           this.keepLoadingClass = true
           if (typeof json.data.redirected === 'string') {
             window.location.href = json.data.redirected
+          } else {
+            window.location.reload()
           }
-          window.location.reload()
         } else {
           throw new Error('Invalid response - JSON missing data/success or data/state_html')
         }

--- a/app/components/folio/console/form_modal_component.js
+++ b/app/components/folio/console/form_modal_component.js
@@ -72,6 +72,9 @@ window.Folio.Stimulus.register('f-c-form-modal', class extends window.Stimulus.C
           window.Folio.Api.flashMessageFromMeta(json)
         } else if (json && json.data && json.data.redirected) {
           this.keepLoadingClass = true
+          if (typeof json.data.redirected === 'string') {
+            window.location.href = json.data.redirected
+          }
           window.location.reload()
         } else {
           throw new Error('Invalid response - JSON missing data/success or data/state_html')


### PR DESCRIPTION
Allow passing redirect url (location) with anchor as query param to form modal. That way the client can work with the newly set anchor after the modal reloads the page.

`/example/url?_anchor=24` received from the client -> `/example/url#24` set before page reload