### PR TITLE
feat: Set user's time zone in the console new user form

### DIFF
--- a/app/controllers/folio/console/users_controller.rb
+++ b/app/controllers/folio/console/users_controller.rb
@@ -42,6 +42,7 @@ class Folio::Console::UsersController < Folio::Console::BaseController
 
   def new
     @user.creating_in_console = 1
+    @user.time_zone = Time.zone.name
   end
 
   def create

--- a/app/models/folio/user.rb
+++ b/app/models/folio/user.rb
@@ -64,6 +64,7 @@ class Folio::User < Folio::ApplicationRecord
                                   dependent: :nullify
 
   validate :validate_one_of_names
+  validates :time_zone, inclusion: { in: ActiveSupport::TimeZone.all.map(&:name) }
 
   validates :email,
             uniqueness: { scope: :auth_site, case_sensitive: false },

--- a/app/views/folio/console/users/_form.slim
+++ b/app/views/folio/console/users/_form.slim
@@ -31,6 +31,8 @@
 
         = f.input :born_at
 
+        = f.input :time_zone, as: :select, collection: ActiveSupport::TimeZone.all.map { |tz| [tz.name, tz.name] }
+
       .col-xxl-4
         = f.input :admin_note,
                   autosize: true,

--- a/app/views/folio/console/users/_show_basic_data.slim
+++ b/app/views/folio/console/users/_show_basic_data.slim
@@ -2,6 +2,7 @@
   = show_for @user do |s|
     = s.attribute :email
       == mail_to(s.object.email, s.object.email)
+    = s.attribute :time_zone
 
     - if ::Rails.application.config.folio_users_use_phone
       = s.attribute :phone

--- a/config/locales/activerecord.cs.yml
+++ b/config/locales/activerecord.cs.yml
@@ -126,6 +126,7 @@ cs:
         full_name: Jméno
         nickname: Přezdívka
         subscribed_to_newsletter: Přihlášení do newsletteru
+        time_zone: Časové pásmo
         locked: :activerecord.attributes.folio/site_user_link.locked
         locked/true: :activerecord.attributes.folio/site_user_link.locked/true
         locked/false: :activerecord.attributes.folio/site_user_link.locked/false

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -59,7 +59,9 @@ Folio::User.create!(first_name: "Test",
                     email: "test@test.test",
                     password: "test@test.test",
                     confirmed_at: Time.current,
-                    superadmin: true)
+                    superadmin: true,
+                    auth_site_id: Folio::Site.first.id
+                   )
 puts "Created Folio::User test@test.test (superadmin)"
 
 puts "Creating Dummy::Menu::Nestable"


### PR DESCRIPTION
Prosím o okomentování a případný merge. Zůstala nám v https://github.com/sinfin/folio/commit/c42a28839eff37d5ad961e135b1689e90faad0c2 nedotažená správa `User.time_zone`, kterou potřebujeme aktuálně pro jiný projekt, který přepíná interpretaci datumu podle TZ uživatele.