### PR TITLE
fix url manipulation

### DIFF
--- a/app/assets/javascripts/folio/add_params_to_url.js
+++ b/app/assets/javascripts/folio/add_params_to_url.js
@@ -1,6 +1,10 @@
 window.Folio = window.Folio || {}
 
 window.Folio.addParamsToUrl = (urlString, paramsHash) => {
+  if (!/^https?:\/\//.test(urlString)) {
+    urlString = window.location.origin + urlString;
+  }
+  
   const url = new URL(urlString)
 
   Object.keys(paramsHash).forEach((key) => {

--- a/app/assets/javascripts/folio/remove_params_from_url.js
+++ b/app/assets/javascripts/folio/remove_params_from_url.js
@@ -1,6 +1,10 @@
 window.Folio = window.Folio || {}
 
 window.Folio.removeParamsFromUrl = (urlString, paramNames) => {
+  if (!/^https?:\/\//.test(urlString)) {
+    urlString = window.location.origin + urlString;
+  }
+
   const url = new URL(urlString)
 
   if (!url.search) return urlString


### PR DESCRIPTION
- v economii a nejspíš i v dalších projektech nefungovalo vyhledávání
- `new URL()` totiž vyžaduje absolutní URL, my tady předávali relativní, což skončilo errorem