### PR TITLE
cabaktom/addresses fields refactor

### DIFF
--- a/app/cells/folio/addresses/fields/show.slim
+++ b/app/cells/folio/addresses/fields/show.slim
@@ -17,22 +17,23 @@
                       disabled: options[:disabled],
                       input_html: { id: nil }
 
-  .row
-    - if show_born_at_fields?
-      div class=column_size_class_name(6)
-        = model.input :born_at,
-                      required: attribute_required?(:born_at),
-                      disabled: options[:disabled],
-                      input_html: { id: nil }
+  - if show_born_at_fields? || options[:phone] != false
+    .row
+      - if show_born_at_fields?
+        div class=column_size_class_name(6)
+          = model.input :born_at,
+                        required: attribute_required?(:born_at),
+                        disabled: options[:disabled],
+                        input_html: { id: nil }
 
-    - if options[:phone] != false
-      div class=column_size_class_name(6)
-        = model.input :phone,
-                      as: :phone,
-                      default_country_code: data_country_code(:primary_address),
-                      disabled: options[:disabled],
-                      required: options[:phone_required] || attribute_required?(:phone),
-                      input_html: { id: nil }
+      - if model.object.respond_to?(:phone) && options[:phone] != false
+        div class=column_size_class_name(6)
+          = model.input :phone,
+                        as: :phone,
+                        default_country_code: data_country_code(:primary_address),
+                        disabled: options[:disabled],
+                        required: options[:phone_required] || attribute_required?(:phone),
+                        input_html: { id: nil }
 
   - if show_primary_address_fields?
     .f-addresses-fields__fields-wrap[

--- a/app/cells/folio/addresses/fields/show.slim
+++ b/app/cells/folio/addresses/fields/show.slim
@@ -17,12 +17,21 @@
                       disabled: options[:disabled],
                       input_html: { id: nil }
 
-  - if show_born_at_fields?
-    .row
+  .row
+    - if show_born_at_fields?
       div class=column_size_class_name(6)
         = model.input :born_at,
-                      required: false,
+                      required: attribute_required?(:born_at),
                       disabled: options[:disabled],
+                      input_html: { id: nil }
+
+    - if options[:phone] != false
+      div class=column_size_class_name(6)
+        = model.input :phone,
+                      as: :phone,
+                      default_country_code: data_country_code(:primary_address),
+                      disabled: options[:disabled],
+                      required: options[:phone_required] || attribute_required?(:phone),
                       input_html: { id: nil }
 
   - if show_primary_address_fields?
@@ -31,7 +40,7 @@
       data-country-code=data_country_code(:primary_address)
     ]
       - model.simple_fields_for :primary_address do |g|
-        - required = required?(:primary_address, g.object.attributes)
+        - required = address_attributes_required?(:primary_address, g.object.attributes)
 
         - if options[:primary_address_name]
           = g.input :name,
@@ -65,16 +74,8 @@
                       input_html: { id: nil }
 
         .row
-          div class=column_size_class_name(6)
+          div class=column_size_class_name(12)
             = country_code_input(g, disabled: options[:disabled])
-
-          div class=column_size_class_name(6)
-            = g.input :phone,
-                      as: :phone,
-                      default_country_code: data_country_code(:primary_address),
-                      disabled: options[:disabled],
-                      required: options[:phone_required],
-                      input_html: { id: nil }
 
   - if show_secondary_address_fields?
     .f-addresses-fields__nested
@@ -85,7 +86,7 @@
             data-country-code=data_country_code(:secondary_address)
           ]
             - model.simple_fields_for :secondary_address do |g|
-              - required = required?(:secondary_address, g.object.attributes)
+              - required = address_attributes_required?(:secondary_address, g.object.attributes)
               = g.input :company_name,
                         disabled: options[:disabled],
                         input_html: { id: nil }

--- a/app/cells/folio/addresses/fields_cell.rb
+++ b/app/cells/folio/addresses/fields_cell.rb
@@ -21,15 +21,16 @@ class Folio::Addresses::FieldsCell < Folio::ApplicationCell
     { tag: options[:title_tag] || "h2", class: "mt-0" }
   end
 
-  def required?(key, attributes)
+  def address_attributes_required?(key, attributes)
     return true if model.object.send("should_validate_#{key}?")
     all_blank = attributes.all? { |attr, val| attr == "type" || val.blank? }
     !all_blank
   end
 
-  def required_phone?(g)
-    g.object.class.validators_on(:phone).any? do |validator|
-      validator.kind_of?(ActiveRecord::Validations::PresenceValidator)
+  def attribute_required?(key)
+    model.object.class.validators_on(key.to_sym).any? do |validator|
+      validator.kind_of?(ActiveRecord::Validations::PresenceValidator) &&
+        (validator.options[:if].nil? || model.object.send(validator.options[:if]))
     end
   end
 

--- a/test/controllers/folio/users/invitations_controller_test.rb
+++ b/test/controllers/folio/users/invitations_controller_test.rb
@@ -67,7 +67,9 @@ class Folio::Users::InvitationsControllerTest < ActionDispatch::IntegrationTest
         invitation_token: user.raw_invitation_token,
         password: "New@Password.123",
         password_confirmation: "New@Password.123",
-        primary_address_attributes: build(:folio_address_primary).attributes
+        primary_address_attributes: build(:folio_address_primary).attributes,
+        born_at: 20.years.ago,
+        phone: "+420604123456"
       }
     }
 


### PR DESCRIPTION
Přesunul jsem telefon z adresy na uživatele, ale nejsem si jistý jestli to takhle použité nebylo záměrně. Ve zbytku aplikace v Auctify je telefon vždycky na uživateli.

Nová metoda `attribute_required?` v `field_cell.rb` mi umožní rozhodovat o povinnosti atributů přidáním validací na modelu. To potřebuju pro validaci `born_at` a `phone` jen pro některé uživatele v Auctify