### PR TITLE
State cell will show only events allowed to user +

### DIFF
--- a/app/cells/folio/console/publishable_inputs/item/show.slim
+++ b/app/cells/folio/console/publishable_inputs/item/show.slim
@@ -3,6 +3,7 @@ div class=class_name data=data
     = f.input field,
               hint: false,
               as: :boolean,
+              disabled: read_only?,
               input_html: input_html('checkbox', checkbox: true),
               wrapper_html: { class: 'f-c-publishable-inputs-item__group' },
               atom_setting: model[:atom_setting] == false ? nil : field
@@ -12,6 +13,7 @@ div class=class_name data=data
         = f.input "#{field}_at",
                   label: false,
                   hint: false,
+                  disabled: read_only?,
                   wrapper_html:,
                   input_html: input_html('input', placeholder: t('.at')),
                   atom_setting: model[:atom_setting] == false ? nil : "#{field}_at"
@@ -21,6 +23,7 @@ div class=class_name data=data
         = f.input "#{field}_from",
                   label: false,
                   hint: false,
+                  disabled: read_only?,
                   wrapper_html:,
                   input_html: input_html('input', placeholder: t('.from')),
                   atom_setting: model[:atom_setting] == false ? nil : "#{field}_from"
@@ -28,6 +31,7 @@ div class=class_name data=data
         = f.input "#{field}_until",
                   label: false,
                   hint: false,
+                  disabled: read_only?,
                   wrapper_html:,
                   input_html: input_html('input', placeholder: t('.to')),
                   atom_setting: model[:atom_setting] == false ? nil : "#{field}_until"

--- a/app/cells/folio/console/publishable_inputs/item_cell.rb
+++ b/app/cells/folio/console/publishable_inputs/item_cell.rb
@@ -11,6 +11,24 @@ class Folio::Console::PublishableInputs::ItemCell < Folio::ConsoleCell
     model[:field]
   end
 
+  def read_only?
+    if @read_only.nil?
+      input_to_event = {
+        published: :publish,
+        featured: :feature
+      }
+
+      @read_only = if Folio::Current.user.blank?
+        false
+      elsif !input_to_event.key?(field.to_sym)
+        false
+      else
+        !can_now?(input_to_event[field.to_sym], f.object, site: Folio::Current.site)
+      end
+    end
+    @read_only
+  end
+
   def date_at?
     return @date_at unless @date_at.nil?
     @date_at = f.object.respond_to?("#{field}_at")

--- a/app/cells/folio/console/state_cell.rb
+++ b/app/cells/folio/console/state_cell.rb
@@ -42,9 +42,8 @@ class Folio::Console::StateCell < Folio::ConsoleCell
     end
   end
 
-  def events
-    @events ||= model.aasm.events(permitted: true)
-                          .reject { |e| e.options[:private] }
+  def events(*args)
+    @events ||= model.allowed_events_for(Folio::Current.user, *args)
   end
 
   def form(&block)

--- a/app/controllers/folio/console/api/aasm_controller.rb
+++ b/app/controllers/folio/console/api/aasm_controller.rb
@@ -8,9 +8,7 @@ class Folio::Console::Api::AasmController < Folio::Console::Api::BaseController
       if record.valid?
         event_name = params.require(:aasm_event).to_sym
 
-        event = record.aasm
-                      .events(possible: true)
-                      .find { |e| e.name == event_name }
+        event = record.allowed_events_for(Folio::Current.user).find { |e| e.name == event_name }
 
         if event && !event.options[:private]
           record = handle_record_before_event(record)

--- a/app/lib/folio/application_cell.rb
+++ b/app/lib/folio/application_cell.rb
@@ -67,7 +67,7 @@ class Folio::ApplicationCell < Cell::ViewModel
   end
 
   # same as in Folio::ApplicationControllerBase but using "options hacks"
-  def can_now?(action, object = nil)
+  def can_now?(action, object = nil, site: nil)
     object ||= current_site
     (current_user || Folio::User.new).can_now_by_ability?(current_ability, action, object)
   end

--- a/app/models/concerns/folio/has_aasm_states.rb
+++ b/app/models/concerns/folio/has_aasm_states.rb
@@ -19,6 +19,14 @@ module Folio::HasAasmStates
     def permitted_event_names(*args) # some quards may need parameter
       aasm.events({ permitted: true }, *args).map(&:name)
     end
+
+    def allowed_events_for(user, *args)
+      return [] unless user
+
+      aasm.events({ permitted: true }, *args).select do |event|
+        !event.options[:private] && user.can_now?(event.name.to_sym, self)
+      end
+    end
   end
 
   private

--- a/test/cells/folio/console/state_cell_test.rb
+++ b/test/cells/folio/console/state_cell_test.rb
@@ -3,15 +3,48 @@
 require "test_helper"
 
 class Folio::Console::StateCellTest < Folio::Console::CellTest
-  test "show" do
+  test "show displays no events without current user" do
     lead = create(:folio_lead)
 
     html = cell("folio/console/state", lead).(:show)
-    assert_match("aasm_event=to_handled", html.find_all(".dropdown-item").last.native["data-url"])
+
+    state_div = html.find(".f-c-state", text: "K vyřízení")
+    assert state_div.present?
+    # no current user => no events
+    assert_not state_div.has_css?(".dropdown-item")
+  end
+
+  test "show displays no events, if current user do not have allowed actions" do
+    lead = create(:folio_lead)
+    assert_equal [:to_pending, :to_handled], lead.permitted_event_names
+    Folio::Current.user = create(:folio_site_user_link, roles: [], site: lead.site).user
+
+    html = cell("folio/console/state", lead).(:show)
+
+    state_div = html.find(".f-c-state", text: "K vyřízení")
+    assert state_div.present?
+    # no admin user => no events
+    assert_not state_div.has_css?(".dropdown-item")
+  end
+
+  test "administrator can see allowed events" do
+    lead = create(:folio_lead)
+    assert_equal [:to_pending, :to_handled], lead.permitted_event_names
+    Folio::Current.user = create(:folio_site_user_link, roles: [:administrator], site: lead.site).user
+
+    html = cell("folio/console/state", lead).(:show)
+
+    state_div = html.find(".f-c-state", text: "K vyřízení")
+    assert state_div.present?
+
+    assert state_div.find(".dropdown-item", text: "Označit jako vyřizovaný")["data-url"].include?("aasm_event=to_pending")
+    assert state_div.find(".dropdown-item", text: "Vyřídit")["data-url"].include?("aasm_event=to_handled")
 
     lead.to_handled!
 
     html = cell("folio/console/state", lead).(:show)
-    assert_match("aasm_event=to_submitted", html.find_all(".dropdown-item")[0].native["data-url"])
+    state_div = html.find(".f-c-state", text: "Vyřízeno")
+    assert state_div.find(".dropdown-item", text: "Označit jako vyřizovaný")["data-url"].include?("aasm_event=to_pending")
+    assert state_div.find(".dropdown-item", text: "Označit jako nevyřízený")["data-url"].include?("aasm_event=to_submitted")
   end
 end


### PR DESCRIPTION
+ publishable_inputs cell zobrazí `disabled` form pokud uživatel nemá právo na `publish` nebo `feature`.

State cell (v konzoli) nabízela eventy dostupné od AASM, bez omezení na to co uživatel může. Pokus o provedení by byl úspěšný.
Upravil jsem to tak, že nabízí jen eventy dostupné uživateli. A pokud se přesto pokusí provést jiný event, tak se vrátí 422.
Chyba se ale nikde vizuálně nevypíše, jen se prostě nezmění stav.


Vtipné je, že se by publishable_inputs využívají i na jiné boolean inputy viz [economia articles](https://github.com/sinfin/economia/blob/master/app/components/folio/console/economia/articles/fields_component.slim#L20)