### PR TITLE
newsletter subscription only to auth site

### DIFF
--- a/app/models/concerns/folio/has_newsletter_subscriptions.rb
+++ b/app/models/concerns/folio/has_newsletter_subscriptions.rb
@@ -10,7 +10,7 @@ module Folio::HasNewsletterSubscriptions
 
     accepts_nested_attributes_for :newsletter_subscriptions, reject_if: :new_record?
 
-    after_create :create_newsletter_subscriptions
+    # after_create :create_newsletter_subscriptions # subscription is created only after_invitation_accepted
     after_update :update_newsletter_subscriptions
   end
 
@@ -21,32 +21,23 @@ module Folio::HasNewsletterSubscriptions
   private
     def create_newsletter_subscriptions
       return unless newsletter_subscriptions_enabled?
+      return unless auth_site.present?
 
-      subscribable_sites = Folio::NewsletterSubscription.subscribable_sites
+      existing_subcription = newsletter_subscriptions.by_site(auth_site).first
 
-      if respond_to?(:source_site) && source_site.present? && source_site.in?(subscribable_sites)
-        subscribable_source_site = source_site
-      end
+      if existing_subcription.nil?
+        ns = auth_site.newsletter_subscriptions.build(
+          email: subscription_email,
+          merge_vars: subscription_merge_vars,
+          tags: subscription_tags,
+          active: should_subscribe_to_newsletter?,
+          subscribable: self
+        )
 
-      present_site_ids = newsletter_subscriptions.map(&:site_id)
-      to_create = subscribable_sites.reject { |site| site.id.in?(present_site_ids) }
-      to_create.each do |site|
-        ns = site.newsletter_subscriptions.find_by_email(subscription_email) || site.newsletter_subscriptions.build(email: subscription_email)
-
-        if subscribable_source_site.present?
-          active = subscribable_source_site == site
-        else
-          active = should_subscribe_to_newsletter?
-        end
-
-        did_create = ns.update(email: subscription_email,
-                                merge_vars: subscription_merge_vars,
-                                tags: subscription_tags,
-                                active:,
-                                subscribable: self)
+        did_create = ns.save
 
         unless did_create
-          Raven.capture_message("NewsletterSubscription for #{self.class.model_name.human} ##{id} - email \"#{subscription_email}\", site \"#{site.env_aware_domain}\" - failed to create.") if defined?(Raven)
+          Raven.capture_message("NewsletterSubscription for #{self.class.model_name.human} ##{id} - email \"#{subscription_email}\"; site \"#{auth_site.env_aware_domain}\" - failed to create.") if defined?(Raven)
         end
       end
 
@@ -55,26 +46,26 @@ module Folio::HasNewsletterSubscriptions
 
     def update_newsletter_subscriptions
       return unless newsletter_subscriptions_enabled?
+      return unless auth_site.present?
 
-      Folio::NewsletterSubscription.subscribable_sites.each do |site|
-        ns = newsletter_subscriptions.by_site(site).first
+      ns = newsletter_subscriptions.by_site(auth_site).first
 
-        if ns.nil? && should_subscribe_to_newsletter?
-          ns = Folio::NewsletterSubscription.find_or_initialize_by(email: subscription_email, site:)
+      if ns.nil?
+        if should_subscribe_to_newsletter?
+          ns = Folio::NewsletterSubscription.find_or_initialize_by(email: subscription_email, site: auth_site)
           ns.subscribable = self
         else
-          # no need for NS record - user isn't subscribed
           return
         end
+      end
 
-        did_update = ns.update(email: subscription_email,
-                                merge_vars: subscription_merge_vars,
-                                tags: subscription_tags,
-                                active: should_subscribe_to_newsletter?)
+      did_update = ns.update(email: subscription_email,
+                             merge_vars: subscription_merge_vars,
+                             tags: subscription_tags,
+                             active: should_subscribe_to_newsletter?)
 
-        unless did_update
-          Raven.capture_message("NewsletterSubscription for #{self.class.model_name.human} ##{id} - email \"#{subscription_email}\"; site `#{site.env_aware_domain}`- failed to update.") if defined?(Raven)
-        end
+      unless did_update
+        Raven.capture_message("NewsletterSubscription for #{self.class.model_name.human} ##{id} - email \"#{subscription_email}\"; site \"#{auth_site.env_aware_domain}\" - failed to update.") if defined?(Raven)
       end
     end
 

--- a/app/models/folio/newsletter_subscription.rb
+++ b/app/models/folio/newsletter_subscription.rb
@@ -15,8 +15,6 @@ class Folio::NewsletterSubscription < Folio::ApplicationRecord
   validates :email,
             uniqueness: { scope: :site_id }
 
-  validate :validate_belongs_to_subscribable_site
-
   default_scope { order(id: :desc) }
 
   scope :active, -> { where(active: true) }
@@ -69,10 +67,6 @@ class Folio::NewsletterSubscription < Folio::ApplicationRecord
     end
   end
 
-  def self.subscribable_sites
-    Folio::Site.all
-  end
-
   private
     def update_mailchimp_subscription(email_for_subscription)
       return unless Rails.application.config.folio_newsletter_subscription_service == :mailchimp
@@ -82,10 +76,6 @@ class Folio::NewsletterSubscription < Folio::ApplicationRecord
       if Folio::Site.count == 1
         Folio::Mailchimp::CreateOrUpdateSubscriptionJob.perform_later(email_for_subscription)
       end
-    end
-
-    def validate_belongs_to_subscribable_site
-      errors.add(:site, :invalid) unless site.in?(self.class.subscribable_sites)
     end
 end
 


### PR DESCRIPTION
Uživatelé budou subscribed pouze k newsletteru jejich `auth_site`.

- Teď se to vytvářelo pro všechny sites, takže nově vytvořená site měla najednou subscriptions od neexistujících uživatelů.
- Zároveň nefungovalo měnění subscription mezi `active: true` a `active: false` (špatná podmínka a `return` pod původním komentářem `# no need for NS record - user isn't subscribed`).
- Subscription se vytvoří až když uživatel přijme pozvánku (teď to bylo při vytvoření uživatele i při přijetí pozvánky).

Po nasazení bude potřeba pročistit databázi a zanechat jen subscriptions, které jsou odpovídají uživatelově `auth_site`

```
Folio::NewsletterSubscription.where(subscribable_type: "Folio::User").each do |sub|
  if sub.site_id != sub.subscribable.auth_site_id
    sub.destroy!
  end
end
```

Nevím jak se to propisuje do MailChimpu nebo kde se s tím subscription pracuje - tak si nejsem jistý, jestli to není taky někde jinde špatně.