### PR TITLE
Usage of Cancancan_accessible_by_action --  removed

### DIFF
--- a/app/cells/folio/console/catalogue_cell.rb
+++ b/app/cells/folio/console/catalogue_cell.rb
@@ -128,18 +128,21 @@ class Folio::Console::CatalogueCell < Folio::ConsoleCell
     attribute(:type) { record.class.model_name.human }
   end
 
-  def edit_link(attr = nil, sanitize: false, &block)
+  def show_or_edit_link(attr = nil, sanitize: false, &block)
     if can_now?(:edit, record)
-      resource_link(through_aware_console_url_for(record, action: :edit), attr, sanitize:, &block)
+      true_edit_link(attr, sanitize:, &block)
     else
-      attribute(attr) do
-        if block_given?
-          yield(record)
-        else
-          record.send(attr)
-        end
-      end
+      show_link(attr, sanitize:, &block)
     end
+  end
+
+  def true_edit_link(attr = nil, sanitize: false, &block)
+    resource_link(through_aware_console_url_for(record, action: :edit), attr, sanitize:, &block)
+  end
+
+  # capturing legacy usage
+  def edit_link(attr = nil, sanitize: false, &block)
+    show_or_edit_link(attr, sanitize:, &block)
   end
 
   def show_link(attr = nil, sanitize: false, &block)

--- a/app/cells/folio/console/catalogue_cell.rb
+++ b/app/cells/folio/console/catalogue_cell.rb
@@ -129,7 +129,17 @@ class Folio::Console::CatalogueCell < Folio::ConsoleCell
   end
 
   def edit_link(attr = nil, sanitize: false, &block)
-    resource_link(through_aware_console_url_for(record, action: :edit), attr, sanitize:, &block)
+    if can_now?(:edit, record)
+      resource_link(through_aware_console_url_for(record, action: :edit), attr, sanitize:, &block)
+    else
+      attribute(attr) do
+        if block_given?
+          yield(record)
+        else
+          record.send(attr)
+        end
+      end
+    end
   end
 
   def show_link(attr = nil, sanitize: false, &block)
@@ -247,6 +257,8 @@ class Folio::Console::CatalogueCell < Folio::ConsoleCell
   end
 
   def position_controls(opts = {})
+    return unless can_now?(:update, record)
+
     attribute(:position, class_name: "position-buttons") do
       cell("folio/console/index/position_buttons",
            record,
@@ -302,12 +314,15 @@ class Folio::Console::CatalogueCell < Folio::ConsoleCell
   def transportable_dropdown
     return unless ::Rails.application.config.folio_show_transportable_frontend
     return unless record.try(:transportable?)
+    return unless can_now?(:update, record)
+    # allows tom create record() from YAML dump
     attribute(:transportable_dropdown, compact: true, skip_desktop_header: true) do
       cell("folio/console/transportable/dropdown", record)
     end
   end
 
   def console_notes
+    # TODO: restrict - only for can_now?(:update, record)
     attribute(:console_notes, compact: true, skip_desktop_header: true) do
       cell("folio/console/console_notes/catalogue_tooltip", record)
     end

--- a/app/cells/folio/console/index/new_button_cell.rb
+++ b/app/cells/folio/console/index/new_button_cell.rb
@@ -2,7 +2,7 @@
 
 class Folio::Console::Index::NewButtonCell < Folio::ConsoleCell
   def show
-    render if button_model.present?
+    render if can_now?(:new, model[:klass]) && button_model.present?
   end
 
   def button_model

--- a/app/cells/folio/console/publishable_inputs/item_cell.rb
+++ b/app/cells/folio/console/publishable_inputs/item_cell.rb
@@ -18,12 +18,12 @@ class Folio::Console::PublishableInputs::ItemCell < Folio::ConsoleCell
         featured: :feature
       }
 
+      ability_action = input_to_event[field.to_sym] || field.to_sym
+
       @read_only = if Folio::Current.user.blank?
         false
-      elsif !input_to_event.key?(field.to_sym)
-        false
       else
-        !can_now?(input_to_event[field.to_sym], f.object, site: Folio::Current.site)
+        !can_now?(ability_action, f.object, site: Folio::Current.site)
       end
     end
     @read_only

--- a/app/cells/folio/console/show/header/show.slim
+++ b/app/cells/folio/console/show/header/show.slim
@@ -31,14 +31,14 @@ div class=class_name
                 icon: :open_in_new,
                 label: t('folio.console.actions.preview'))
 
-      - if options[:edit] != false && edit_url
+      - if options[:edit] != false && edit_url && can_now?(:edit, model)
         == cell('folio/console/ui/button',
                 href: edit_url,
                 variant: :secondary,
                 icon: :edit,
                 label: t('folio.console.actions.edit'))
 
-      - if destroy_url
+      - if destroy_url && can_now?(:destroy, model)
         == cell('folio/console/ui/button',
                 href: destroy_url,
                 variant: :danger,

--- a/app/controllers/concerns/folio/console/default_actions.rb
+++ b/app/controllers/concerns/folio/console/default_actions.rb
@@ -4,7 +4,7 @@ module Folio::Console::DefaultActions
   extend ActiveSupport::Concern
 
   def index
-    records = folio_console_records.accessible_by(current_ability, self.class.cancancan_accessible_by_action)
+    records = folio_console_records
 
     unless @sorted_by_param
       if records.respond_to?(:ordered)

--- a/app/controllers/concerns/folio/console/default_actions.rb
+++ b/app/controllers/concerns/folio/console/default_actions.rb
@@ -36,6 +36,9 @@ module Folio::Console::DefaultActions
     end
   end
 
+  def show
+  end
+
   def edit
     folio_console_record.valid? if params[:prevalidate]
   end

--- a/app/controllers/folio/console/base_controller.rb
+++ b/app/controllers/folio/console/base_controller.rb
@@ -462,11 +462,8 @@ class Folio::Console::BaseController < Folio::ApplicationController
 
     def filter_records_by_belongs_to_site
       if folio_console_records
-        records = folio_console_records.accessible_by(current_ability,
-                                                      self.class.cancancan_accessible_by_action)
-
         instance_variable_set(folio_console_record_variable_name(plural: true),
-                              records.by_site(allowed_record_sites))
+                              folio_console_records.by_site(allowed_record_sites))
       elsif record = folio_console_record
         if record.persisted? && !allowed_record_sites.map(&:id).include?(record.site.id)
           raise ActiveRecord::RecordNotFound
@@ -553,10 +550,6 @@ class Folio::Console::BaseController < Folio::ApplicationController
 
     def set_show_current_user_console_path_bar
       @show_current_user_console_path_bar = %w[edit update].include?(action_name)
-    end
-
-    def self.cancancan_accessible_by_action
-      :update
     end
 
     def member_action?

--- a/app/controllers/folio/console/pages_controller.rb
+++ b/app/controllers/folio/console/pages_controller.rb
@@ -7,8 +7,6 @@ class Folio::Console::PagesController < Folio::Console::BaseController
     @catalogue_options = {}
 
     if Rails.application.config.folio_pages_ancestry
-      @pages = @pages.accessible_by(current_ability, self.class.cancancan_accessible_by_action)
-
       @catalogue_model = @pages.arrange(order: :position)
       @catalogue_options = { ancestry: true }
     else

--- a/app/models/folio/page.rb
+++ b/app/models/folio/page.rb
@@ -174,27 +174,25 @@ end
 #
 # Table name: folio_pages
 #
-#  id                                 :bigint(8)        not null, primary key
-#  title                              :string
-#  slug                               :string
-#  perex                              :text
-#  meta_title                         :string(512)
-#  meta_description                   :text
-#  ancestry                           :string
-#  type                               :string
-#  position                           :integer
-#  published                          :boolean
-#  published_at                       :datetime
-#  original_id                        :integer
-#  locale                             :string(6)
-#  created_at                         :datetime         not null
-#  updated_at                         :datetime         not null
-#  ancestry_slug                      :string
-#  site_id                            :bigint(8)
-#  atoms_data_for_search              :text
-#  preview_token                      :string
-#  folio_audited_atoms_data           :jsonb
-#  folio_audited_file_placements_data :jsonb
+#  id                    :bigint(8)        not null, primary key
+#  title                 :string
+#  slug                  :string
+#  perex                 :text
+#  meta_title            :string(512)
+#  meta_description      :text
+#  ancestry              :string
+#  type                  :string
+#  position              :integer
+#  published             :boolean
+#  published_at          :datetime
+#  original_id           :integer
+#  locale                :string(6)
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  ancestry_slug         :string
+#  site_id               :bigint(8)
+#  atoms_data_for_search :text
+#  preview_token         :string
 #
 # Indexes
 #

--- a/app/models/folio/page/cookies.rb
+++ b/app/models/folio/page/cookies.rb
@@ -8,27 +8,25 @@ end
 #
 # Table name: folio_pages
 #
-#  id                                 :bigint(8)        not null, primary key
-#  title                              :string
-#  slug                               :string
-#  perex                              :text
-#  meta_title                         :string(512)
-#  meta_description                   :text
-#  ancestry                           :string
-#  type                               :string
-#  position                           :integer
-#  published                          :boolean
-#  published_at                       :datetime
-#  original_id                        :integer
-#  locale                             :string(6)
-#  created_at                         :datetime         not null
-#  updated_at                         :datetime         not null
-#  ancestry_slug                      :string
-#  site_id                            :bigint(8)
-#  atoms_data_for_search              :text
-#  preview_token                      :string
-#  folio_audited_atoms_data           :jsonb
-#  folio_audited_file_placements_data :jsonb
+#  id                    :bigint(8)        not null, primary key
+#  title                 :string
+#  slug                  :string
+#  perex                 :text
+#  meta_title            :string(512)
+#  meta_description      :text
+#  ancestry              :string
+#  type                  :string
+#  position              :integer
+#  published             :boolean
+#  published_at          :datetime
+#  original_id           :integer
+#  locale                :string(6)
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  ancestry_slug         :string
+#  site_id               :bigint(8)
+#  atoms_data_for_search :text
+#  preview_token         :string
 #
 # Indexes
 #

--- a/test/controllers/folio/console/leads_controller_test.rb
+++ b/test/controllers/folio/console/leads_controller_test.rb
@@ -19,6 +19,50 @@ class Folio::Console::LeadsControllerTest < Folio::Console::BaseControllerTest
     assert_response :success
   end
 
+  test "index scoped by ability and site" do
+    other_site = create(:folio_site, type: "Folio::Site")
+    our_site_lead1 = create(:folio_lead, site: @site, email: "our1@lead.com")
+    our_site_lead2 = create(:folio_lead, site: @site, email: "manager_cant@see.me")
+    our_site_lead3 = create(:folio_lead, site: @site, email: "manager_can_read_but_not_update@see.me")
+    other_site_lead = create(:folio_lead, site: other_site, email: "other@lead.com")
+
+    I18n.with_locale(:cs) do
+      get url_for([:console, Folio::Lead])
+    end
+
+    assert_response :success
+    assert_select ".f-c-pagination__info", text: "Zobrazuji 3 záznamy"
+    assert_select ".f-c-catalogue__row", count: 3
+    assert_select ".f-c-catalogue__row .f-c-catalogue__cell-value", text: our_site_lead1.email, count: 1
+    assert_select ".f-c-catalogue__row .f-c-catalogue__cell-value", text: our_site_lead2.email, count: 1
+    assert_select ".f-c-catalogue__row .f-c-catalogue__cell-value", text: our_site_lead3.email, count: 1
+    assert_select ".f-c-catalogue__row .f-c-catalogue__cell-value", text: other_site_lead.email, count: 0
+
+    sign_out(@superadmin)
+    manager = create(:folio_site_user_link, site: @site, roles: [:manager]).user
+    sign_in manager
+
+    I18n.with_locale(:cs) do
+      get url_for([:console, Folio::Lead])
+    end
+
+    assert_response :success
+    # manager can not see lead with email "manager_cant@see.me" (see dummy ability override)
+    assert_select ".f-c-pagination__info", text: "Zobrazuji 2 záznamy"
+    assert_select ".f-c-catalogue__row", count: 2
+    assert_select ".f-c-catalogue__row .f-c-catalogue__cell-value", text: our_site_lead1.email, count: 1
+    assert_select ".f-c-catalogue__row .f-c-catalogue__cell-value", text: our_site_lead2.email, count: 0
+    assert_select ".f-c-catalogue__row .f-c-catalogue__cell-value", text: our_site_lead3.email, count: 1
+    assert_select ".f-c-catalogue__row .f-c-catalogue__cell-value", text: other_site_lead.email, count: 0
+
+    sign_out(manager)
+  end
+
+  def teardown
+    super
+ end
+
+
   test "edit" do
     model = create(:folio_lead)
     get url_for([:edit, :console, model])

--- a/test/dummy/app/overrides/models/folio/ability_override.rb
+++ b/test/dummy/app/overrides/models/folio/ability_override.rb
@@ -10,6 +10,7 @@ Folio::Ability.class_eval do
 
   def dummy_rules
     dummy_blog_rules
+    dummy_test_rules if Rails.env.test?
   end
 
   def dummy_blog_rules
@@ -19,6 +20,14 @@ Folio::Ability.class_eval do
       can :do_anything, Dummy::Blog::Article, { site: }
       can :do_anything, Dummy::Blog::Author, { site: }
       can :do_anything, Dummy::Blog::Topic, { site: }
+    end
+  end
+
+  def dummy_test_rules
+    # for ability scopes testing
+    if user.has_any_roles?(site:, roles: [:manager])
+      cannot :read, Folio::Lead, { site:, email: "manager_cant@see.me" }
+      cannot :update, Folio::Lead, { site:, email: "manager_can_read_but_not_update@see.me" }
     end
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema[7.1].define(version: 2024_10_21_105052) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_09_152500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -73,7 +72,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_21_105052) do
     t.datetime "updated_at", null: false
     t.index ["dummy_blog_article_id"], name: "dummy_blog_author_article_links_a_id"
     t.index ["dummy_blog_author_id"], name: "dummy_blog_author_article_links_t_id"
-    t.index ["position"], name: "index_dummy_blog_author_article_links_on_position"
   end
 
   create_table "dummy_blog_authors", force: :cascade do |t|
@@ -136,7 +134,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_21_105052) do
     t.datetime "updated_at", null: false
     t.index ["dummy_blog_article_id"], name: "dummy_blog_topic_article_links_a_id"
     t.index ["dummy_blog_topic_id"], name: "dummy_blog_topic_article_links_t_id"
-    t.index ["position"], name: "index_dummy_blog_topic_article_links_on_position"
   end
 
   create_table "dummy_blog_topics", force: :cascade do |t|


### PR DESCRIPTION
1) Nahradil jsem  používání  `folio_records.accessible_by(current_ability, self.class.cancancan_accessible_by_action)` za 
`folio_records.accessible_by(current_ability)` , což při použití `load_and_authorize_resource` je totéž jako `folio_records` .
Tj. načítají se záznamy povolené uživateli pro danou akci controlleru.  
Pokud je tam nějaká specifická mimo CRUD, je potřeba ji  nastavit v abilitách.

2) Některé helpery pro consoli jsem upravil tak, aby si sami kontrolovali, jestli na danou akci má uživatel právo či nikoliv.
    A podle toho buď zobrazili input nebo jen read-only input. 
   Např u`published_toggle` se místo toggle zobrazí jen "Ano" nebo "Ne", pokud nemáte právo to měnit. 
  U zatržítek se input zobrazí, ale je disabled.