### PR TITLE
feat: dont filter by site klass option in autocomplete

### DIFF
--- a/app/controllers/folio/console/api/autocompletes_controller.rb
+++ b/app/controllers/folio/console/api/autocompletes_controller.rb
@@ -13,7 +13,9 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
 
       scope = klass.accessible_by(Folio::Current.ability)
 
-      scope = scope.by_site(current_site) if scope.respond_to?(:by_site)
+      if !klass.try(:console_api_autocomplete_dont_filter_by_site)
+        scope = scope.by_site(current_site) if scope.respond_to?(:by_site)
+      end
       scope = apply_param_scope(scope)
 
       params.each do |key, val|


### PR DESCRIPTION
radek 15 `scope = klass.accessible_by(Folio::Current.ability)` filtruje pro site adminy korektne pristupne uzivatele, pro superadminy je vracena kolekce vsech uzivatelu, ale  radek 16 `scope = scope.by_site(current_site) if scope.respond_to?(:by_site)` je potom hned vyfiltruje - pouzijeme check na tridni metode (ve foliolized_auctify user override)
```
def self.console_api_autocomplete_dont_filter_by_site
  true
end
```

![image](https://github.com/user-attachments/assets/2ecde790-1753-495d-ab1d-bb7899d0b412)
