### PR TITLE
domanhtu/sidebar-delimiter

### DIFF
--- a/app/cells/folio/console/layout/sidebar/show.slim
+++ b/app/cells/folio/console/layout/sidebar/show.slim
@@ -20,8 +20,16 @@ aside#f-c-layout-sidebar.f-c-layout-sidebar data-controller="f-c-layout-sidebar"
                 = group[:title]
 
             ul.f-c-layout-sidebar__ul
-              - group[:links].each do |link|
-                li.f-c-layout-sidebar__li
-                  == link
+              - group[:links].each do |link_group|
+                .f-c-layout-sidebar__subgroup
+                  - link_group.each do |link|
+                    - if link.is_a?(Array)
+                      .f-c-layout-sidebar__subgroup
+                        - link.each do |l|
+                          li.f-c-layout-sidebar__li
+                            == l
+                    - else
+                      li.f-c-layout-sidebar__li
+                        == link
 
     = render(:_appended)

--- a/app/cells/folio/console/layout/sidebar/sidebar.sass
+++ b/app/cells/folio/console/layout/sidebar/sidebar.sass
@@ -47,6 +47,12 @@
   &__group--collapsed &__part-title::after
     transform: translate(0, -50%) rotate(180deg)
 
+  &__subgroup
+    border-bottom: 1px solid rgba($gray, 0.4227)
+
+  &__subgroup:last-child
+    border-bottom: none
+
   &__ul
     margin: 0
     padding: $grid-gutter-width / 4 0


### PR DESCRIPTION
preveden sidebar_cell, aby bral format nested arrays
na kazde urovni vnoreni se ptame, jestli je array nebo ne a podle toho se rozhodujeme, zda vratime uz link nebo jdeme jeste o uroven niz

```rb
def self.console_sidebar_prepended_links
    [
      "Project::Model",
      [
        "Project::ModelInSubgroup",
        "Project::AnotherModelInSubgroup",
      ],
      "Project::OutOfSubGroup",
      [
        "Project::FooModelInSubgroup",
        "Project::FooAnotherModelInSubgroup",
      ],
      [
        "Project::BarModelInSubgroup",
        "Project::BarAnotherModelInSubgroup",
      ],
      "Project::LastOne",
    ]
end
```

v Auctify pote muzeme customizovat skupiny
```rb
def self.console_sidebar_prepended_links
    [
      %w[
      Auctify::Item
      Auctify::CategorySiteLink
      Auctify::Artist
      Auctify::SalesPack
      Auctify::BidderRegistration
      Auctify::Sale::Retail
      Auctify::PriceRequest
      ],
      %w[
        Auctify::Features::DocumentTemplate::Base
        Auctify::Features::Contract::Base
        ],
      %w[
        Auctify::Location
        Auctify::ShippingMethod
        Auctify::PaymentMethod
        Auctify::Order
        Auctify::Features::Submissions::Submission
        Folio::AttributeType
      ],
    ]
  end
```

<img width="147" alt="image" src="https://github.com/user-attachments/assets/2cc947cf-0858-4c02-8677-490ee191f45a">

