### PR TITLE
feat(dropdown): add divider with optional title

### DIFF
--- a/app/assets/stylesheets/folio/console/_variables.sass
+++ b/app/assets/stylesheets/folio/console/_variables.sass
@@ -143,6 +143,7 @@ $dropdown-padding-y: 0.5rem
 $dropdown-item-padding-y: 2 / 3 * 1rem
 $dropdown-item-padding-x: 1rem
 $dropdown-box-shadow:               $box-shadow !default;
+$dropdown-divider-color: $gray-medium-dark
 
 $enable-rfs: false
 $enable-validation-icons: false

--- a/app/assets/stylesheets/folio/console/bootstrap-overrides/_dropdown.sass
+++ b/app/assets/stylesheets/folio/console/bootstrap-overrides/_dropdown.sass
@@ -3,3 +3,18 @@
 
 .dropdown-item
   font-weight: $font-weight-bold
+
+.dropdown-divider
+  display: flex
+  align-items: center
+  gap: $grid-gutter-width / 4
+  pointer-events: none
+
+  &__title
+    font-weight: $font-weight-light
+    font-size: $font-size-sm
+    color: $dropdown-link-color
+
+  &__line
+    flex-grow: 1
+    border-top: 1px solid $dropdown-divider-color

--- a/app/cells/folio/console/dropdown/show.slim
+++ b/app/cells/folio/console/dropdown/show.slim
@@ -3,8 +3,14 @@
 
   .dropdown-menu class=('dropdown-menu-right' if menu_align == :right)
     - links.each do |link|
-      == cell('folio/console/ui/with_icon',
-              link[:title],
-              href: link[:url],
-              class: 'dropdown-item',
-              icon: link[:icon])
+      - if link[:divider]
+        .dropdown-item.dropdown-divider
+          - if link[:title]
+            span.dropdown-divider__title = link[:title]
+          .dropdown-divider__line
+      - else
+        == cell('folio/console/ui/with_icon',
+                link[:title],
+                href: link[:url],
+                class: 'dropdown-item',
+                icon: link[:icon])


### PR DESCRIPTION
```
== cell('folio/console/dropdown',
      title: t('.export'),
      links: [
              { title: "First item", url: ... },
              { title: "Second item with long title", url: ... },
              { title: "Third item", url: ... },
              { title: "Divider title", divider: true },
              { title: "Fourth item", url: ... }
            ],
      button_model: { icon: :download, variant: :secondary })
```

<img width="215" alt="image" src="https://github.com/user-attachments/assets/dbd69287-f171-420e-9177-c8c3410881f5" />
