### PR TITLE
feat(notification_modal): added href to confirm button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- added href to confirm button in `Folio::Console::Ui::NotificationModalComponent`
+
 ## [6.1.3] - 2025-02-20
 
 ### Fixed

--- a/app/components/folio/console/ui/notification_modal_component.js
+++ b/app/components/folio/console/ui/notification_modal_component.js
@@ -122,6 +122,17 @@ window.Folio.Stimulus.register('f-c-ui-notification-modal', class extends window
         })
       }
 
+      if (data.confirm_with_link) {
+        const label = data.confirm_with_link.label
+        const href = data.confirm_with_link.href
+        buttonsData.push({
+          variant: 'primary',
+          href: href,
+          label: typeof label === "string" ? label : window.Folio.i18n(window.FolioConsole.Ui.NotificationModal.i18n, 'confirm'),
+          data: { action: 'f-c-ui-notification-modal#confirm' }
+        })
+      }
+
       footer.innerHTML = ''
       footer.appendChild(window.FolioConsole.Ui.Buttons.create(buttonsData))
     } else {

--- a/app/components/folio/console/ui/notification_modal_component.js
+++ b/app/components/folio/console/ui/notification_modal_component.js
@@ -122,7 +122,7 @@ window.Folio.Stimulus.register('f-c-ui-notification-modal', class extends window
         })
       }
 
-      if (data.confirm_with_link) {
+      if (data.confirm_with_link && data.confirm_with_link.href) {
         const label = data.confirm_with_link.label
         const href = data.confirm_with_link.href
         buttonsData.push({


### PR DESCRIPTION
Přidána možnost předat `href` pro tlačítko `confirm` u Folio::Console::Ui::NotificationModalComponent.