### PR TITLE
update_newsletter_subscriptions only if email is changed or user confirmed

### DIFF
--- a/app/models/concerns/folio/has_newsletter_subscriptions.rb
+++ b/app/models/concerns/folio/has_newsletter_subscriptions.rb
@@ -47,6 +47,7 @@ module Folio::HasNewsletterSubscriptions
     end
 
     def update_newsletter_subscriptions
+      return unless saved_changes.key?("email") || saved_changes.key?("invitation_accepted_at")
       return unless newsletter_subscriptions_enabled?
       return unless auth_site.present?
 


### PR DESCRIPTION
Jinak se  `update_newsletter_subscriptions` volal po každém user update. Což bylo mimo jiné po každém přihlášení.