### PR TITLE
halirdan/merger form footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - use `only_path: true` for file sidebar links when `folio_shared_files_between_sites`
 - allow hiding settings and 'share preview' in  `form_footer`
+- fix hiding settings in `form_footer`
+- add support for custom submit label in `form_footer` 
+- fix merges form using `form_footer` component instead of outdated cell
+
 
 ## [6.3.1] - 2025-04-24
 

--- a/app/cells/folio/console/merges/form/show.slim
+++ b/app/cells/folio/console/merges/form/show.slim
@@ -19,7 +19,11 @@
                                                    row: row, \
                                                    f: f)
 
-                                                   = form_footer f
+      = render_view_component(Folio::Console::Form::FooterComponent.new(f:,
+                                                                        preview_path: false,
+                                                                        share_preview: false,
+                                                                        show_settings: false,
+                                                                        submit_label: t('.submit')))
 
   - else
     .f-c-merges-form__invalid.mt-3

--- a/app/components/folio/console/form/footer_component.rb
+++ b/app/components/folio/console/form/footer_component.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class Folio::Console::Form::FooterComponent < Folio::Console::ApplicationComponent
-  def initialize(f: nil, preview_path: nil, share_preview: false, show_settings: true)
+  def initialize(f: nil, preview_path: nil, share_preview: false, show_settings: true, submit_label: nil)
     @f = f
     @preview_path = preview_path
     @share_preview = share_preview
     @show_settings = show_settings
+    @submit_label = submit_label
   end
 
   def before_render

--- a/app/components/folio/console/form/footer_component.slim
+++ b/app/components/folio/console/form/footer_component.slim
@@ -45,19 +45,18 @@
                   icon: :open_in_new,
                   target: "_blank",
                   data: { test_id: "preview-button" })
+        - if @show_settings
+          .f-c-form-footer__collapsible
+            .f-c-form-footer__collapsible-backdrop data=stimulus_action_unless_audit(click: "toggleCollapsed")
+            .f-c-form-footer__collapsible-content
+              - if @record
+                - unless @audit
+                  = render(Folio::Console::Autosave::ToggleComponent.new(record: @record))
 
-        .f-c-form-footer__collapsible
-          .f-c-form-footer__collapsible-backdrop data=stimulus_action_unless_audit(click: "toggleCollapsed")
-          .f-c-form-footer__collapsible-content
-            - if @record
-              - unless @audit
-                = render(Folio::Console::Autosave::ToggleComponent.new(record: @record))
+                = render(Folio::Console::Audited::DropdownComponent.new(audits: controller.instance_variable_get(:@audited_audits),
+                                                                        audit: @audit,
+                                                                        record: @record))
 
-              = render(Folio::Console::Audited::DropdownComponent.new(audits: controller.instance_variable_get(:@audited_audits),
-                                                                      audit: @audit,
-                                                                      record: @record))
-
-            - if @show_settings
               .f-c-form-footer__settings
                 .f-c-form-footer__settings-toggle.small.text-muted[
                   data=stimulus_action_unless_audit(click: "toggleSettings")
@@ -75,19 +74,19 @@
                 .f-c-form-footer__settings-content
                   = render(Folio::Console::HtmlAutoFormat::ToggleComponent.new)
 
-            - if @share_preview
-              .f-c-form-footer__share.small.text-muted data=stimulus_modal_toggle(Folio::Console::SharePreviewModalComponent::CLASS_NAME)
-                == cell('folio/console/ui/with_icon',
-                        t('.share'),
-                        hover: :underline,
-                        icon: :link,
-                        icon_options: { height: 16 })
+              - if @share_preview
+                .f-c-form-footer__share.small.text-muted data=stimulus_modal_toggle(Folio::Console::SharePreviewModalComponent::CLASS_NAME)
+                  == cell('folio/console/ui/with_icon',
+                          t('.share'),
+                          hover: :underline,
+                          icon: :link,
+                          icon_options: { height: 16 })
 
-          == cell('folio/console/ui/button',
-                  class: 'f-c-form-footer__btn f-c-form-footer__btn--collapsible',
-                  variant: :gray,
-                  icon: :dots_vertical,
-                  data: (stimulus_action_unless_audit(click: "toggleCollapsed") || {}).merge(test_id: "dropdown-button"))
+            == cell('folio/console/ui/button',
+                    class: 'f-c-form-footer__btn f-c-form-footer__btn--collapsible',
+                    variant: :gray,
+                    icon: :dots_vertical,
+                    data: (stimulus_action_unless_audit(click: "toggleCollapsed") || {}).merge(test_id: "dropdown-button"))
 
 javascript:
   if (window.sessionStorage.getItem('fCAutosaveUiState')) {

--- a/app/components/folio/console/form/footer_component.slim
+++ b/app/components/folio/console/form/footer_component.slim
@@ -14,7 +14,7 @@
                     type: :submit,
                     class: 'f-c-form-footer__btn f-c-form-footer__btn--submit',
                     variant: :primary,
-                    label: t("folio.console.actions.submit"),
+                    label: @submit_label || t("folio.console.actions.submit"),
                     icon: :check,
                     data: stimulus_target('submitButton').merge(test_id: "submit-button"),
                     html_left: content_tag(:span, nil, class: "f-c-form-footer__submit-btn-indicator", data: stimulus_target('submitButtonIndicator')))


### PR DESCRIPTION
- opravil jsem schování setting ve `form_footeru`
- přidal jsem submit label do `form_footeru`
- opravil jsem `merges form`, nezobrazoval se footer (po předělání footeru do komponenty)