### PR TITLE
Improve Folio docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Full English documentation lives in the `docs/` folder:
 | Troubleshooting | [docs/troubleshooting.md](docs/troubleshooting.md) |
 | Upgrade & Migration | [docs/upgrade.md](docs/upgrade.md) |
 | Extending & Customisation | [docs/extending.md](docs/extending.md) |
+| Concerns | [docs/concerns.md](docs/concerns.md) |
+| Jobs | [docs/jobs.md](docs/jobs.md) |
+| Seeding | [docs/seeding.md](docs/seeding.md) |
+| Sitemaps | [docs/sitemap.md](docs/sitemap.md) |
 | FAQ | [docs/faq.md](docs/faq.md) |
 
 Start with the [Overview](docs/overview.md) and follow the *Quick Start* guide.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,7 @@ classDiagram
 
 - [← Back to Overview](overview.md)
 - [Next: Components →](components.md)
-- [Atoms](atoms.md) | [Admin Console](admin.md) | [Files & Media](files.md)
+- [Atoms](atoms.md) | [Admin Console](admin.md) | [Files & Media](files.md) | [Concerns](concerns.md) | [Jobs](jobs.md)
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -8,6 +8,8 @@ This chapter describes the component-based architecture of the Folio Rails Engin
 
 Folio uses a modern, modular approach to UI development based on [ViewComponent](https://viewcomponent.org/). Components are organized for clarity, reusability, and maintainability, following BEM naming conventions and leveraging Stimulus for JavaScript behavior. React components can also be integrated for advanced interactivity.
 
+Legacy Trailblazer Cells are still bundled for backwards compatibility but are scheduled for removal in the next major release.
+
 ---
 
 ## Creating Components (Recommended: Generator)
@@ -92,19 +94,7 @@ classDiagram
     UiComponent <|-- NestedFieldsComponent
 ```
 
-*Note: This is a simplified example. Actual component hierarchy may vary.*
 
----
-
-## Navigation
-
-- [← Back to Overview](overview.md)
-- [← Back to Architecture](architecture.md)
-- [Next: Atoms →](atoms.md)
-- [Admin Console](admin.md) | [Files & Media](files.md)
-- [Extending & Customization](extending.md)
-
----
 
 ## Advanced Component Topics
 
@@ -137,6 +127,8 @@ Projects that need React UI pieces should:
 See the old wiki page *Working-with-react-in-folio* for a complete webpack example.
 
 ---
+
+*Note: This is a simplified example. Actual component hierarchy may vary.*
 
 ## Navigation
 

--- a/docs/concerns.md
+++ b/docs/concerns.md
@@ -1,0 +1,33 @@
+# Concerns
+
+Folio extracts shared functionality into Ruby modules located under `app/models/concerns/folio/` and `app/controllers/concerns/folio/`. These modules can be mixed into your own classes to add behaviour or helper scopes.
+
+## Model Concerns
+
+| Module | Purpose |
+|--------|---------|
+| `HasAtoms` | Adds association and helpers for CMS block atoms |
+| `Thumbnails` | Generates and manages image thumbnails |
+| `Publishable` | Common scopes and callbacks for published/unpublished state |
+| `Positionable` / `PositionableDescending` | Ordering helpers for sortable lists |
+| `BelongsToSite` | Adds `site` relation used for multi‑site projects |
+| `Filterable` | Provides `filter_by_params` and dynamic `by_*` scopes |
+| `Taggable` | Adds tagging via `acts-as-taggable-on` |
+| `HasSecretHash` | Generates a unique token for secure URLs |
+
+See the source under [`app/models/concerns/folio`](../app/models/concerns/folio) for the full list.
+
+## Controller Concerns
+
+Controller modules live in `app/controllers/concerns/folio`. Important ones include:
+
+- `ApplicationControllerBase` – sets `Folio::Current` context
+- `PagesControllerBase` – helpers for page rendering
+- `ApiControllerBase` – JSON API helpers
+- `Console::DefaultActions` – common CRUD actions for admin controllers
+
+Include these modules in custom controllers as needed.
+
+---
+
+[← Back to Architecture](architecture.md)

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -90,8 +90,7 @@ Folio ships with several helper tasks located in `lib/tasks/`:
 
 | Task | Purpose |
 |------|---------|
-| `rake folio:file:metadata` | Extract missing EXIF/IPTC metadata for existing images |
-| `rake folio:file:fill_missing_metadata` | Same as above, but for all file types |
+| `rake folio:file:fill_missing_metadata` | Extract missing EXIF/IPTC metadata for all files |
 | `rake folio:session_attachments:clear_unpaired` | Remove unused temporary attachments |
 | `rake folio:developer_tools:idp_fill_up_site_to_folio_records` | Back-fill `site_id` on legacy records |
 | `rake folio:developer_tools:idp_split_users_to_sites` | Split users to individual sites after cross-domain auth removal |

--- a/docs/files.md
+++ b/docs/files.md
@@ -89,7 +89,7 @@ Once installed, metadata of every new image is stored in `Folio::File::Image.fil
 
 For existing uploads run:
 ```bash
-rake folio:file:metadata
+rake folio:file:fill_missing_metadata
 ```
 You can inspect a single image in the console:
 ```ruby

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -1,0 +1,17 @@
+# Jobs & Background Processing
+
+Folio defines many `ActiveJob` classes under `app/jobs/folio/`. See the [jobs directory](../app/jobs/folio) for the full list. They handle tasks such as file processing and media uploads. Some notable jobs are:
+
+| Job class | Purpose |
+|-----------|---------|
+| `GenerateThumbnailJob` | Creates image thumbnails asynchronously |
+| `Files::SetAdditionalDataJob` | Extracts dominant colour and animation info |
+| `DeleteThumbnailsJob` | Cleans up thumbnails when a file is removed |
+| `CraMediaCloud::CreateMediaJob` | Uploads videos to CraMediaCloud encoding service |
+| `InvalidUsersCheckJob` | Raises an error when invalid users are detected |
+
+Jobs use Sidekiq by default (see `config.active_job.queue_adapter`). They also broadcast updates to the admin console via MessageBus when applicable.
+
+---
+
+[← Back to Architecture](architecture.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -20,6 +20,10 @@ Welcome to the documentation for the **Folio Rails Engine**. This project provid
 - [Troubleshooting](troubleshooting.md) — Common issues and solutions
 - [Upgrade & Migration](upgrade.md) — Upgrading projects, migration guides
 - [Extending & Customization](extending.md) — Generators, overrides, custom code
+- [Concerns](concerns.md) — Reusable model and controller modules
+- [Jobs](jobs.md) — Background processing overview
+- [Seeding](seeding.md) — Demo data & tasks
+- [Sitemaps](sitemap.md) — XML sitemap generation
 - [FAQ](faq.md) — Frequently asked questions
 
 ---
@@ -63,19 +67,6 @@ Welcome to the documentation for the **Folio Rails Engine**. This project provid
 - Using generators, writing custom extensions, and overriding engine behavior.
 
 **FAQ:**
-- Short answers to common questions and practical tips.
-
----
-
-## Navigation
-
-- [Next: Architecture →](architecture.md)
-- [Components](components.md) | [Atoms](atoms.md) | [Admin Console](admin.md) | [Files & Media](files.md)
-
----
-
-*For more information, see the individual chapters linked above. This documentation will be updated as new content is reviewed and migrated from legacy sources.*
-
 ## Key Features at a Glance
 
 - **Modular CMS Engine** – Pages composed of reusable CMS blocks (Atoms)
@@ -124,8 +115,10 @@ app/
   controllers/folio/     # Public & admin controllers
   overrides/             # Safe place for engine overrides
   cells/                 # Legacy Trailblazer Cells (deprecated)
-lib/generators/folio/    # Rich set of generators
+  lib/generators/folio/    # Rich set of generators
 ```
+
+Trailblazer Cells will be removed in favour of ViewComponents in the next major release.
 
 See individual chapters for deeper dives into components, atoms, files, etc.
 
@@ -145,9 +138,18 @@ Ensure these binaries are present on CI / production servers.
 
 ## Conventions & Roadmap
 
-- New UI code should use **ViewComponent**; **Trailblazer Cells** remain for legacy only.
+- New UI code should use **ViewComponent**. Support for **Trailblazer Cells** is deprecated and will be removed in the next major release.
 - Follow **BEM** for SASS class names.
 - Place project-specific patches in `app/overrides/` to stay upgrade-safe.
 - Prefer generators over hand-written boilerplate.
 
 --- 
+
+## Navigation
+
+- [Next: Architecture →](architecture.md)
+- [Components](components.md) | [Atoms](atoms.md) | [Admin Console](admin.md) | [Files & Media](files.md) | [Concerns](concerns.md) | [Jobs](jobs.md) | [Sitemaps](sitemap.md)
+
+---
+
+*For more information, see the individual chapters linked above. This documentation will be updated as new content is reviewed and migrated from legacy sources.*

--- a/docs/seeding.md
+++ b/docs/seeding.md
@@ -1,0 +1,17 @@
+# Seeding & Demo Data
+
+The install generator places seed helpers under `lib/tasks/developer_tools.rake` and YAML files in `data/seed/`.
+
+Useful tasks:
+
+| Task | Description |
+|------|-------------|
+| `rake developer_tools:idp_seed_all` | Load sites, pages and menus from YAML |
+| `rake folio:email_templates:idp_seed` | Import email templates from `data/email_templates*.yml` |
+| `rake developer_tools:idp_seed_dummy_images` | Download Unsplash images for local development |
+
+Run these after `rails db:seed` to bootstrap a new project. The tasks are safe to run multiple times and can be forced via `FORCE=1`.
+
+---
+
+[← Back to Overview](overview.md)

--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -1,0 +1,13 @@
+# Sitemaps
+
+Folio ships with helpers for generating XML sitemaps via the [`sitemap_generator`](https://github.com/kjvarga/sitemap_generator) gem.
+
+- Configure your sitemap in `config/sitemap.rb`. See `test/dummy/config/sitemap.rb` for a working example.
+- Use the `Folio::Sitemap` concern on models (`Page`, `File::Image`, …) to expose image data.
+- Generated sitemap files are uploaded to S3 and served by `Folio::SitemapsController` from `/sitemaps/:id.xml.gz`.
+
+Run `rake sitemap:refresh` to build the files. Make sure environment variables `S3_REGION` and `S3_BUCKET_NAME` are set.
+
+---
+
+[← Back to Overview](overview.md)


### PR DESCRIPTION
## Summary
- add docs on concerns, jobs, seeding and sitemaps
- fix Rake task name in file docs
- clarify Trailblazer Cells deprecation
- link new docs from README and navigation
- fix navigation placement and crosslink in docs

## Testing
- `bundle exec rails test` *(fails: `bundle: command not found`)*