### PR TITLE
feat(picker): add extension hook for additional content

### DIFF
--- a/app/cells/folio/console/file/picker/show.slim
+++ b/app/cells/folio/console/file/picker/show.slim
@@ -48,3 +48,7 @@
                      height: 12,
                      class: 'f-c-file-picker__alt-ico',
                      data: { action: "click->f-c-file-picker#onAltClick" })
+    
+    / Extension hook for additional content
+    - if additional_content
+      == additional_content

--- a/app/cells/folio/console/file/picker_cell.rb
+++ b/app/cells/folio/console/file/picker_cell.rb
@@ -34,4 +34,9 @@ class Folio::Console::File::PickerCell < Folio::ConsoleCell
       fail "Unknown human_type #{klass.human_type}"
     end
   end
+
+  # Extension hook for additional content after picker
+  def additional_content
+    nil
+  end
 end


### PR DESCRIPTION
Add additional_content method to Folio::Console::File::PickerCell to allow applications to extend the picker with custom functionality without overriding the entire cell.

This provides a clean extension point for adding features like placement-specific metadata editing in consuming applications.