### PR TITLE
feat(links): add default custom URL option to link components

### DIFF
--- a/app/assets/javascripts/folio/input/url.js
+++ b/app/assets/javascripts/folio/input/url.js
@@ -30,6 +30,7 @@ window.Folio.Input.Url.initFormGroup = (formGroup, opts = {}) => {
   formGroup.setAttribute('data-f-c-input-form-group-url-loaded-value', 'false')
   formGroup.setAttribute('data-f-c-input-form-group-url-json-value', opts.json ? 'true' : 'false')
   formGroup.setAttribute('data-f-c-input-form-group-only-path-value', opts.absoluteUrls ? 'true' : 'false')
+  formGroup.setAttribute('data-f-c-input-form-group-default-custom-url-value', opts.defaultCustomUrl ? 'true' : 'false')
   formGroup.setAttribute('data-action', 'f-c-input-form-group-url:edit->f-c-input-form-group-url#edit f-c-input-form-group-url:remove->f-c-input-form-group-url#remove')
 
   formGroup.insertAdjacentHTML('beforeend', `
@@ -49,7 +50,8 @@ window.Folio.Stimulus.register('f-c-input-form-group-url', class extends window.
   static values = {
     loaded: Boolean,
     json: Boolean,
-    absoluteUrls: { type: Boolean, default: false }
+    absoluteUrls: { type: Boolean, default: false },
+    defaultCustomUrl: { type: Boolean, default: false }
   }
 
   static targets = ['input']
@@ -83,7 +85,7 @@ window.Folio.Stimulus.register('f-c-input-form-group-url', class extends window.
     }
 
     const baseUrl = '/console/api/links/control_bar'
-    const data = { json: this.jsonValue, absolute_urls: this.absoluteUrlsValue }
+    const data = { json: this.jsonValue, absolute_urls: this.absoluteUrlsValue, default_custom_url: this.defaultCustomUrlValue }
 
     if (this.jsonValue) {
       data.url_json = this.inputTarget.value || '{}'
@@ -130,11 +132,13 @@ window.Folio.Stimulus.register('f-c-input-form-group-url', class extends window.
 
     const json = e.detail.json !== false
     const absoluteUrls = e.detail.absoluteUrls === true
+    const defaultCustomUrl = e.detail.defaultCustomUrl === true
 
     const detail = {
       urlJson,
       json,
       absoluteUrls,
+      defaultCustomUrl,
       trigger: this,
     }
 

--- a/app/components/folio/console/links/control_bar_component.js
+++ b/app/components/folio/console/links/control_bar_component.js
@@ -2,6 +2,7 @@ window.Folio.Stimulus.register('f-c-links-control-bar', class extends window.Sti
   static values = {
     json: Boolean,
     absoluteUrls: { type: Boolean, default: false },
+    defaultCustomUrl: { type: Boolean, default: false },
   }
 
   onAddClick (e) {
@@ -9,7 +10,7 @@ window.Folio.Stimulus.register('f-c-links-control-bar', class extends window.Sti
 
     this.element.dispatchEvent(new CustomEvent('f-c-input-form-group-url:edit', {
       bubbles: true,
-      detail: { json: this.jsonValue, absoluteUrls: this.absoluteUrlsValue }
+      detail: { json: this.jsonValue, absoluteUrls: this.absoluteUrlsValue, defaultCustomUrl: this.defaultCustomUrlValue }
     }))
   }
 })

--- a/app/components/folio/console/links/control_bar_component.rb
+++ b/app/components/folio/console/links/control_bar_component.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class Folio::Console::Links::ControlBarComponent < Folio::Console::ApplicationComponent
-  def initialize(url_json: {}, href: nil, json: true, absolute_urls: false)
+  def initialize(url_json: {}, href: nil, json: true, absolute_urls: false, default_custom_url: false)
     @url_json = url_json
 
     @json = json
     @absolute_urls = absolute_urls
+    @default_custom_url = default_custom_url
 
     if @url_json.blank?
       @url_json = { href: }
@@ -26,6 +27,7 @@ class Folio::Console::Links::ControlBarComponent < Folio::Console::ApplicationCo
                           href: @url_json[:href],
                           json: @json,
                           absolute_urls: @absolute_urls,
+                          default_custom_url: @default_custom_url,
                         })
   end
 end

--- a/app/components/folio/console/links/modal/form_component.rb
+++ b/app/components/folio/console/links/modal/form_component.rb
@@ -3,12 +3,13 @@
 class Folio::Console::Links::Modal::FormComponent < Folio::Console::ApplicationComponent
   VALID_REL_VALUES = %w[alternate author bookmark external help license next nofollow noopener noreferrer prev search tag]
 
-  def initialize(url_json:, json: true, preferred_label: nil, absolute_urls: false, disable_label: false)
+  def initialize(url_json:, json: true, preferred_label: nil, absolute_urls: false, disable_label: false, default_custom_url: false)
     @url_json = url_json
     @json = json
     @preferred_label = preferred_label
     @absolute_urls = absolute_urls
     @disable_label = disable_label
+    @default_custom_url = default_custom_url
   end
 
   def data

--- a/app/components/folio/console/links/modal/form_component.slim
+++ b/app/components/folio/console/links/modal/form_component.slim
@@ -1,6 +1,7 @@
 .f-c-links-modal-form data=data
   = render(Folio::Console::Links::Modal::UrlPickerComponent.new(url_json: @url_json,
-                                                                absolute_urls: @absolute_urls))
+                                                                absolute_urls: @absolute_urls,
+                                                                default_custom_url: @default_custom_url))
 
   = simple_form_for "",
                     url: "#",

--- a/app/components/folio/console/links/modal/url_picker_component.rb
+++ b/app/components/folio/console/links/modal/url_picker_component.rb
@@ -3,9 +3,10 @@
 class Folio::Console::Links::Modal::UrlPickerComponent < Folio::Console::ApplicationComponent
   include Folio::Console::Cell::IndexFilters
 
-  def initialize(url_json:, absolute_urls: false)
+  def initialize(url_json:, absolute_urls: false, default_custom_url: false)
     @url_json = url_json
     @absolute_urls = absolute_urls
+    @default_custom_url = default_custom_url
   end
 
   def before_render
@@ -24,7 +25,11 @@ class Folio::Console::Links::Modal::UrlPickerComponent < Folio::Console::Applica
 
   def tabs
     @tabs ||= begin
-      first_active = @record.present? || @url_json[:href].blank?
+      if @default_custom_url
+        first_active = false
+      else
+        first_active = @record.present? || @url_json[:href].blank?
+      end
 
       [
         { label: t(".tab/pick"), key: :pick, active: first_active },
@@ -49,6 +54,7 @@ class Folio::Console::Links::Modal::UrlPickerComponent < Folio::Console::Applica
                           filtering: false,
                           autofocus_input: tabs[1][:active],
                           absolute_urls: @absolute_urls,
+                          default_custom_url: @default_custom_url,
                         })
   end
 

--- a/app/components/folio/console/links/modal_component.js
+++ b/app/components/folio/console/links/modal_component.js
@@ -24,12 +24,13 @@ window.Folio.Stimulus.register('f-c-links-modal', class extends window.Stimulus.
     }
   }
 
-  openWithUrlJson ({ urlJson, trigger, json, absoluteUrls, preferredLabel, disableLabel }) {
+  openWithUrlJson ({ urlJson, trigger, json, absoluteUrls, preferredLabel, disableLabel, defaultCustomUrl }) {
     this.trigger = trigger
     this.preferredLabelValue = preferredLabel
     this.disableLabelValue = disableLabel === true
     this.jsonValue = json !== false
     this.absoluteUrlsValue = absoluteUrls === true
+    this.defaultCustomUrl = defaultCustomUrl === true
 
     this.loadForm(urlJson)
 
@@ -50,6 +51,7 @@ window.Folio.Stimulus.register('f-c-links-modal', class extends window.Stimulus.
       url_json: JSON.stringify(urlJson),
       json: this.jsonValue,
       absolute_urls: this.absoluteUrlsValue,
+      default_custom_url: this.defaultCustomUrl,
       preferred_label: this.preferredLabelValue,
       disable_label: this.disableLabelValue,
     })
@@ -105,6 +107,7 @@ window.Folio.Stimulus.register('f-c-links-modal', class extends window.Stimulus.
         json: e.detail.json,
         disableLabel: e.detail.disableLabel,
         preferredLabel: e.detail.preferredLabel,
+        defaultCustomUrl: e.detail.defaultCustomUrl,
       })
     }
   }

--- a/app/controllers/folio/console/api/links_controller.rb
+++ b/app/controllers/folio/console/api/links_controller.rb
@@ -12,12 +12,14 @@ class Folio::Console::Api::LinksController < Folio::Console::Api::BaseController
 
     json = params[:json] != false && params[:json] != "false"
     absolute_urls = params[:absolute_urls] == true || params[:absolute_urls] == "true"
+    default_custom_url = params[:default_custom_url] == true || params[:default_custom_url] == "true"
 
     render_component_json(Folio::Console::Links::Modal::FormComponent.new(url_json:,
                                                                           json:,
                                                                           absolute_urls:,
                                                                           disable_label: params[:disable_label].to_s == "true",
-                                                                          preferred_label: params[:preferred_label].presence))
+                                                                          preferred_label: params[:preferred_label].presence,
+                                                                          default_custom_url:))
   end
 
   def control_bar
@@ -35,11 +37,13 @@ class Folio::Console::Api::LinksController < Folio::Console::Api::BaseController
 
     json = params[:json] != false && params[:json] != "false"
     absolute_urls = params[:absolute_urls] == true || params[:absolute_urls] == "true"
+    default_custom_url = params[:default_custom_url] == true || params[:default_custom_url] == "true"
 
     render_component_json(Folio::Console::Links::ControlBarComponent.new(url_json:,
                                                                          href:,
                                                                          json:,
-                                                                         absolute_urls:))
+                                                                         absolute_urls:,
+                                                                         default_custom_url:))
   end
 
   def value

--- a/app/overrides/lib/simple_form/inputs/base_override.rb
+++ b/app/overrides/lib/simple_form/inputs/base_override.rb
@@ -119,6 +119,7 @@ SimpleForm::Inputs::Base.class_eval do
                         loaded: false,
                         json:,
                         absolute_urls: (options && options[:absolute_urls]) || false,
+                        default_custom_url: (options && options[:default_custom_url]) || false,
                       },
                       action: {
                         "f-c-input-form-group-url:edit" => "edit",


### PR DESCRIPTION
Na aktuálně je potřeba použít url picker, ale výchozí tab má být custom url, protože v tom konkrétním případě nikdy nepoužijí url z aplikace.
Udělal jsem to po vzoru absolute_urls, tedy se to propaguje přes ty jednotlivé komponenty. Nevím, jestli jsem se však někde nezamotal a neudělal nějakou zbytečnost.