### PR TITLE
Add possibility to hide button for specific attribute errors

### DIFF
--- a/app/cells/folio/console/form/errors/show.slim
+++ b/app/cells/folio/console/form/errors/show.slim
@@ -11,7 +11,7 @@
         span.me-3
           = dig_error_message(error)
 
-        - if options[:buttons] != false
+        - if show_fix_button?(error)
           == cell('folio/console/ui/button',
                   variant: 'danger',
                   size: :sm,

--- a/app/cells/folio/console/form/errors_cell.rb
+++ b/app/cells/folio/console/form/errors_cell.rb
@@ -24,4 +24,11 @@ class Folio::Console::Form::ErrorsCell < Folio::ConsoleCell
       "action" => "f-c-form-errors#onButtonClick"
     }
   end
+
+  def show_fix_button?(error)
+    buttons_enabled = options[:buttons] != false
+    hide_for = Array(options[:hide_btn_for]).map(&:to_s)
+
+    buttons_enabled && hide_for.exclude?(error.attribute.to_s)
+  end
 end

--- a/app/cells/folio/console/form/header/show.slim
+++ b/app/cells/folio/console/form/header/show.slim
@@ -24,4 +24,4 @@
       == cell('folio/console/index/tabs', options[:tabs])
 
   - if model.try(:object).try(:errors).present?
-    == cell('folio/console/form/errors', model)
+    == cell('folio/console/form/errors', model, options.slice(:hide_btn_for))


### PR DESCRIPTION
Měli jsme schůzku s Lukášem a  řekl, že bychom tlačítko neměli odstraňovat, ale že bychom ho neměli dovolit kvůli nějakým chybám. A tohle je moje řešení.
<img width="1463" height="439" alt="Screenshot 2025-09-08 at 09 12 53" src="https://github.com/user-attachments/assets/c3b6ab36-7c8e-4a54-a233-92cd0c4162ce" />

Related to: https://it-economia.atlassian.net/browse/CMS-508
Related to: