### PR TITLE
feat(console): add support for `:separator` in console sidebar links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+- **Console sidebar `:separator` support**: Sites can now include `:separator` in `console_sidebar_prepended_links` (and `before_menu`/`before_site` variants) to insert visual dividers inside custom sidebar sections.
 
 ## [7.6.0] - 2026-04-09
 ### Added

--- a/app/cells/folio/console/layout/sidebar_cell.rb
+++ b/app/cells/folio/console/layout/sidebar_cell.rb
@@ -283,18 +283,14 @@ class Folio::Console::Layout::SidebarCell < Folio::ConsoleCell
 
         site_links = site_specific_links(site)
 
-        if site_links[:console_sidebar_prepended_links].present?
-          links << site_links[:console_sidebar_prepended_links].compact
-        end
+        push_site_link_groups(links, site_links[:console_sidebar_prepended_links])
 
         page_group = []
         page_group << link_for_site_class(site, Folio::Page)
         page_group << homepage_for_site(site)
         links << page_group.compact
 
-        if site_links[:console_sidebar_before_menu_links].present?
-          links << site_links[:console_sidebar_before_menu_links].compact
-        end
+        push_site_link_groups(links, site_links[:console_sidebar_before_menu_links])
 
         menu_group = []
         menu_group << link_for_site_class(site, Folio::Menu)
@@ -304,9 +300,7 @@ class Folio::Console::Layout::SidebarCell < Folio::ConsoleCell
 
         links << menu_group.compact
 
-        if site_links[:console_sidebar_before_site_links].present?
-          links << site_links[:console_sidebar_before_site_links].compact
-        end
+        push_site_link_groups(links, site_links[:console_sidebar_before_site_links])
 
         if can_now?(:update, site)
           links << {
@@ -340,11 +334,32 @@ class Folio::Console::Layout::SidebarCell < Folio::ConsoleCell
           next if (group_links_defs = site.class.try(links_group_key)).blank?
 
           group_links_defs.each do |link_or_hash|
-            site_links[links_group_key] << link_from_definitions(site, link_or_hash)
+            if link_or_hash == :separator
+              site_links[links_group_key] << :separator
+            else
+              site_links[links_group_key] << link_from_definitions(site, link_or_hash)
+            end
           end
         end
       end
       site_links
+    end
+
+    def push_site_link_groups(links, link_items)
+      return if link_items.blank?
+
+      split_links_by_separator(link_items).each do |group|
+        compacted = group.compact
+        links << compacted if compacted.present?
+      end
+    end
+
+    def split_links_by_separator(link_items)
+      return [link_items] unless link_items.include?(:separator)
+
+      link_items.chunk { |item| item == :separator }
+                .reject { |is_sep, _| is_sep }
+                .map(&:last)
     end
 
 


### PR DESCRIPTION
## Folio console sidebar – podpora separátorů v custom menu  
- Do Folio `SidebarCell` přidána podpora `:separator` markeru v metodách `console_sidebar_prepended_links`, `console_sidebar_before_menu_links` a `console_sidebar_before_site_links`      
- `:separator` v poli vytvoří vizuální oddělovací čáru uvnitř custom části sidebar menu (stejný styl jako mezi existujícími sekcemi)                                                       
- Nové private metody: `push_site_link_groups` a `split_links_by_separator`                                                 
- Zpětně kompatibilní — bez `:separator` se chování nemění (zkontrolováno vůči override v Eco a Auctify)