### PR TITLE
fix: keyword search prioritize exact match for files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 
 - **hyperlinks in tiptap editor**: Added autolink to config file to allow override
 - **keep tags field editable**: after choosing a suggestion
+- **file search by slug/keyword**: `by_query` scope now also matches files by slug (ILIKE), so searching by a CMS keyword or slug fragment finds videos and other files
+- **autocomplete exact-match ordering**: all autocomplete endpoints now sort exact-title matches first so pressing Enter selects the expected option
 
 ## [7.5.1] - 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ All notable changes to this project will be documented in this file.
 
 - **hyperlinks in tiptap editor**: Added autolink to config file to allow override
 - **keep tags field editable**: after choosing a suggestion
-- **file search by slug/keyword**: `by_query` scope now also matches files by slug (ILIKE), so searching by a CMS keyword or slug fragment finds videos and other files
 - **autocomplete exact-match ordering**: all autocomplete endpoints now sort exact-title matches first so pressing Enter selects the expected option
 
 ## [7.5.1] - 2026-03-19

--- a/app/controllers/folio/console/api/autocompletes_controller.rb
+++ b/app/controllers/folio/console/api/autocompletes_controller.rb
@@ -34,6 +34,7 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
 
       if q.present?
         if q.length >= AUTOCOMPLETE_QUERY_MIN_LENGTH
+          scope = apply_exact_match_priority(scope, klass, q)
           scope = scope.by_label_query(q)
         else
           render json: { data: [], meta: { page: 1, pages: 1, from: nil, to: nil, count: 0, next: nil } }
@@ -45,19 +46,14 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
 
       if p_order.present? && scope.respond_to?(p_order)
         if has_type_ordering
-          # Type ordering is primary, add p_order as secondary
           scope = scope.send(p_order)
         else
-          # No type ordering, unscope and apply p_order as primary
           scope = scope.unscope(:order).send(p_order)
         end
       elsif q.blank? && p_order.blank? && scope.respond_to?(:ordered)
-        # No query and no order scope, use default ordered scope
         if has_type_ordering
-          # Type ordering is primary, add ordered as secondary
           scope = scope.ordered
         else
-          # No type ordering, unscope and apply ordered as primary
           scope = scope.unscope(:order).ordered
         end
       end
@@ -157,6 +153,7 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
 
       if q.present?
         if q.length >= AUTOCOMPLETE_QUERY_MIN_LENGTH
+          scope = apply_exact_match_priority(scope, klass, q)
           scope = scope.by_label_query(q)
         else
           render_selectize_options([])
@@ -206,6 +203,7 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
 
       if q.present?
         if q.length >= AUTOCOMPLETE_QUERY_MIN_LENGTH
+          scope = apply_exact_match_priority(scope, klass, q)
           scope = scope.by_label_query(q)
         else
           render_select2_options([])
@@ -278,6 +276,7 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
           end
 
           if q.present?
+            scope = apply_exact_match_priority(scope, klass, q)
             scope = scope.by_label_query(q)
           else
             scope = scope.all
@@ -341,6 +340,7 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
             end
 
             if q.present?
+              scope = apply_exact_match_priority(scope, klass, q)
               scope = scope.by_label_query(q)
             else
               scope = scope.all
@@ -448,6 +448,19 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
       end
 
       scope
+    end
+
+    def apply_exact_match_priority(scope, klass, q)
+      label_column = if klass.column_names.include?("title")
+        "title"
+      elsif klass.column_names.include?("name")
+        "name"
+      end
+
+      return scope unless label_column
+
+      quoted_q = ActiveRecord::Base.connection.quote(q.downcase)
+      scope.order(Arel.sql("CASE WHEN LOWER(#{klass.table_name}.#{label_column}) = #{quoted_q} THEN 0 ELSE 1 END"))
     end
 
     def apply_param_scope(scope)

--- a/app/controllers/folio/console/api/autocompletes_controller.rb
+++ b/app/controllers/folio/console/api/autocompletes_controller.rb
@@ -34,7 +34,6 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
 
       if q.present?
         if q.length >= AUTOCOMPLETE_QUERY_MIN_LENGTH
-          scope = apply_exact_match_priority(scope, klass, q)
           scope = scope.by_label_query(q)
         else
           render json: { data: [], meta: { page: 1, pages: 1, from: nil, to: nil, count: 0, next: nil } }
@@ -59,6 +58,7 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
       end
 
       pagination, records = pagy(scope, page: p_page, items: AUTOCOMPLETE_PAGY_ITEMS)
+      records = sort_exact_match_first(records, q) if q.present?
       scope = records.filter_map(&:to_autocomplete_label).uniq
 
       render json: { data: scope, meta: meta_from_pagy(pagination) }
@@ -153,7 +153,6 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
 
       if q.present?
         if q.length >= AUTOCOMPLETE_QUERY_MIN_LENGTH
-          scope = apply_exact_match_priority(scope, klass, q)
           scope = scope.by_label_query(q)
         else
           render_selectize_options([])
@@ -177,7 +176,9 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
         end
       end
 
-      render_selectize_options(scope.limit(AUTOCOMPLETE_PAGY_ITEMS), label_method: params[:label_method])
+      records = scope.limit(AUTOCOMPLETE_PAGY_ITEMS).to_a
+      records = sort_exact_match_first(records, q) if q.present?
+      render_selectize_options(records, label_method: params[:label_method])
     else
       render_selectize_options([])
     end
@@ -203,7 +204,6 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
 
       if q.present?
         if q.length >= AUTOCOMPLETE_QUERY_MIN_LENGTH
-          scope = apply_exact_match_priority(scope, klass, q)
           scope = scope.by_label_query(q)
         else
           render_select2_options([])
@@ -232,6 +232,7 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
       end
 
       pagination, records = pagy(scope, items: AUTOCOMPLETE_PAGY_ITEMS)
+      records = sort_exact_match_first(records, q) if q.present?
 
       render_select2_options(records,
                              label_method: params[:label_method],
@@ -276,7 +277,6 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
           end
 
           if q.present?
-            scope = apply_exact_match_priority(scope, klass, q)
             scope = scope.by_label_query(q)
           else
             scope = scope.all
@@ -305,6 +305,7 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
           scope = filter_by_atom_setting_params(scope)
 
           pagination, records = pagy(scope, page: p_page, items: AUTOCOMPLETE_PAGY_ITEMS)
+          records = sort_exact_match_first(records, q) if q.present?
 
           response = records.map do |record|
             text = record.to_console_label
@@ -340,7 +341,6 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
             end
 
             if q.present?
-              scope = apply_exact_match_priority(scope, klass, q)
               scope = scope.by_label_query(q)
             else
               scope = scope.all
@@ -368,13 +368,12 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
 
             scope = filter_by_atom_setting_params(scope)
 
-            # Get enough records to cover pagination (estimate pages needed)
-            # For simplicity, get AUTOCOMPLETE_PAGY_ITEMS * 2 from each class
             all_records += scope.limit(AUTOCOMPLETE_PAGY_ITEMS * 2).to_a
           end
         end
 
-        # Paginate the combined array manually
+        all_records = sort_exact_match_first(all_records, q) if q.present?
+
         total_count = all_records.size
         total_pages = (total_count.to_f / AUTOCOMPLETE_PAGY_ITEMS).ceil
         offset = (p_page - 1) * AUTOCOMPLETE_PAGY_ITEMS
@@ -450,17 +449,9 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
       scope
     end
 
-    def apply_exact_match_priority(scope, klass, q)
-      label_column = if klass.column_names.include?("title")
-        "title"
-      elsif klass.column_names.include?("name")
-        "name"
-      end
-
-      return scope unless label_column
-
-      quoted_q = ActiveRecord::Base.connection.quote(q.downcase)
-      scope.order(Arel.sql("CASE WHEN LOWER(#{klass.table_name}.#{label_column}) = #{quoted_q} THEN 0 ELSE 1 END"))
+    def sort_exact_match_first(records, q)
+      q_downcase = q.downcase
+      records.sort_by { |r| (r.try(:title) || r.try(:name))&.downcase == q_downcase ? 0 : 1 }
     end
 
     def apply_param_scope(scope)

--- a/test/controllers/folio/console/api/autocompletes_controller_test.rb
+++ b/test/controllers/folio/console/api/autocompletes_controller_test.rb
@@ -340,6 +340,24 @@ class Folio::Console::Api::AutocompletesControllerTest < Folio::Console::BaseCon
     assert_equal("Foo bar baz", json["data"][0]["text"])
   end
 
+  test "show prioritizes exact match over partial match" do
+    create(:folio_page, title: "Foo bar baz")
+    create(:folio_page, title: "Foo")
+
+    get console_api_autocomplete_path(klass: "Folio::Page", q: "Foo")
+    json = JSON.parse(response.body)
+    assert_equal "Foo", json["data"].first
+  end
+
+  test "react_select prioritizes exact match over partial match" do
+    create(:folio_page, title: "Foo bar baz")
+    create(:folio_page, title: "Foo")
+
+    get react_select_console_api_autocomplete_path(class_names: "Folio::Page", q: "Foo")
+    json = JSON.parse(response.body)
+    assert_equal "Foo", json["data"].first["text"]
+  end
+
   test "react_select with multiple classes ignores short queries" do
     create(:folio_page, title: "Foo page")
 


### PR DESCRIPTION
 - When looking for video by keyword it should return exact match, so for example files with text "test" will be returned at top, above "test in something" in title. This will prevent creating new keywords in favor to take already existing                                                                             
