### PR TITLE
fix(console): default shade contrast Sass vars for folio/input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **Console Sass**: `folio/console/_variables.sass` defines `$shade-black-contrast` and `$shade-light-contrast` with `!default` (from `$black` / `$white`) so `folio/input/_phone.sass` compiles in the console stylesheet chain without host-app token files.
+
 ## [7.6.2] - 2026-04-20
 
 ### Added

--- a/app/assets/stylesheets/folio/console/_variables.sass
+++ b/app/assets/stylesheets/folio/console/_variables.sass
@@ -6,6 +6,10 @@ $grid-gutter-half: $grid-gutter-width / 2
 
 $white: #FFFFFF
 $black: #000000
+
+$shade-black-contrast: $black !default
+$shade-light-contrast: $white !default
+
 $dark-gray: #3B4548
 $gray-medium-dark: #6F7172
 $gray: #C9CBCC


### PR DESCRIPTION
folio/input/_phone.sass uses $shade-black-contrast; folio/console/_variables.sass did not define it. Map to $black / $white with !default so the console base chain compiles without host _variables-colors.
