### PR TITLE
creditText improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- **`structured_data_hash_for_cover` `creditText`**: now deduplicates matching `author` / `attribution_source` (e.g. `"Reuters / Reuters"` → `"Reuters"`) and falls back to `file.file_list_source` when both are blank. Previously emitted duplicated values and had no fallback.
-
 ### Fixed
 
 ## [7.6.3] - 2026-04-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Reusable `structured_data_credit_for(file)`**: extracted from `structured_data_hash_for_cover` and made public on `Folio::StructuredData::BodyComponent` so host-app overrides (e.g. `VideoObject`) can format `creditText` consistently with `ImageObject`.
+
 ### Changed
+
+- **`structured_data_hash_for_cover` `creditText`**: now deduplicates matching `author` / `attribution_source` (e.g. `"Reuters / Reuters"` → `"Reuters"`) and falls back to `file.file_list_source` when both are blank. Previously emitted duplicated values and had no fallback.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- **Reusable `structured_data_credit_for(file)`**: extracted from `structured_data_hash_for_cover` and made public on `Folio::StructuredData::BodyComponent` so host-app overrides (e.g. `VideoObject`) can format `creditText` consistently with `ImageObject`.
-
 ### Changed
+
+- **`ImageObject` `creditText`**: now uses `Folio::File#credit_text`, deduplicating matching `author` / `attribution_source` (e.g. `"Reuters / Reuters"` → `"Reuters"`) and falling back to `file_list_source` when both are
+  blank.
 
 ### Fixed
 

--- a/app/components/folio/structured_data/body_component.rb
+++ b/app/components/folio/structured_data/body_component.rb
@@ -211,6 +211,24 @@ class Folio::StructuredData::BodyComponent < Folio::ApplicationComponent
     ].compact_blank.uniq.join(" / ").presence || file.try(:file_list_source).presence
   end
 
+  # Schema.org `creator` entity for `file`. Picks a single primary entity following
+  # the same author → attribution_source → file_list_source priority used by
+  # `structured_data_credit_for`; type is "Person" when the author field provides
+  # the name, otherwise "Organization".
+  def structured_data_creator_for(file)
+    return if file.blank?
+
+    author = file.try(:author).presence
+    source = file.try(:attribution_source).presence || file.try(:file_list_source).presence
+    name = author || source
+    return if name.blank?
+
+    {
+      "@type" => author.present? ? "Person" : "Organization",
+      "name" => name,
+    }
+  end
+
   private
     def record_cover_thumb_size
       @record.try(:structured_data_cover_thumb_size) || Folio::OG_IMAGE_DIMENSIONS

--- a/app/components/folio/structured_data/body_component.rb
+++ b/app/components/folio/structured_data/body_component.rb
@@ -195,38 +195,10 @@ class Folio::StructuredData::BodyComponent < Folio::ApplicationComponent
     {
       "@type" => "ImageObject",
       "url" => thumb.url,
-      "creditText" => structured_data_credit_for(cover),
+      "creditText" => cover.credit_text,
       "width" => thumb.width,
       "height" => thumb.height,
     }.compact
-  end
-
-  def structured_data_credit_for(file)
-    return if file.blank?
-    return file.credit_text if file.respond_to?(:credit_text)
-
-    [
-      file.try(:author).presence,
-      file.try(:attribution_source).presence,
-    ].compact_blank.uniq.join(" / ").presence || file.try(:file_list_source).presence
-  end
-
-  # Schema.org `creator` entity for `file`. Picks a single primary entity following
-  # the same author → attribution_source → file_list_source priority used by
-  # `structured_data_credit_for`; type is "Person" when the author field provides
-  # the name, otherwise "Organization".
-  def structured_data_creator_for(file)
-    return if file.blank?
-
-    author = file.try(:author).presence
-    source = file.try(:attribution_source).presence || file.try(:file_list_source).presence
-    name = author || source
-    return if name.blank?
-
-    {
-      "@type" => author.present? ? "Person" : "Organization",
-      "name" => name,
-    }
   end
 
   private

--- a/app/components/folio/structured_data/body_component.rb
+++ b/app/components/folio/structured_data/body_component.rb
@@ -191,15 +191,23 @@ class Folio::StructuredData::BodyComponent < Folio::ApplicationComponent
     return unless cover.present?
 
     thumb = cover.thumb(record_cover_thumb_size)
-    credit = [cover.try(:author).presence, cover.try(:attribution_source).presence].compact.join(" / ").presence
 
     {
       "@type" => "ImageObject",
       "url" => thumb.url,
-      "creditText" => credit,
+      "creditText" => structured_data_credit_for(cover),
       "width" => thumb.width,
       "height" => thumb.height,
     }.compact
+  end
+
+  def structured_data_credit_for(file)
+    return if file.blank?
+
+    [
+      file.try(:author).presence,
+      file.try(:attribution_source).presence,
+    ].compact_blank.uniq.join(" / ").presence || file.try(:file_list_source).presence
   end
 
   private

--- a/app/components/folio/structured_data/body_component.rb
+++ b/app/components/folio/structured_data/body_component.rb
@@ -203,6 +203,7 @@ class Folio::StructuredData::BodyComponent < Folio::ApplicationComponent
 
   def structured_data_credit_for(file)
     return if file.blank?
+    return file.credit_text if file.respond_to?(:credit_text)
 
     [
       file.try(:author).presence,

--- a/app/models/folio/file.rb
+++ b/app/models/folio/file.rb
@@ -372,6 +372,13 @@ class Folio::File < Folio::ApplicationRecord
     end
   end
 
+  # Combined credit string used for JSON-LD creditText, RSS media:credit, etc.
+  # Joins author and attribution_source (deduplicated) and falls back to
+  # file_list_source when both are blank.
+  def credit_text
+    [author.presence, attribution_source.presence].compact_blank.uniq.join(" / ").presence || file_list_source.presence
+  end
+
   def to_label
     file_name.presence || self.class.model_name.human
   end

--- a/test/components/folio/structured_data/body_component_test.rb
+++ b/test/components/folio/structured_data/body_component_test.rb
@@ -130,21 +130,6 @@ class Folio::StructuredData::BodyComponentTest < Folio::ComponentTest
     assert_equal "Reuters", article_data["image"]["creditText"]
   end
 
-  test "render article image creditText falls back to file_list_source when author and attribution_source are blank" do
-    create_and_host_site
-    article = create(:dummy_blog_article, published_at: Time.current)
-    image = create(:folio_file_image, author: nil, attribution_source: nil, file_list_source: "Wikipedia")
-    create(:folio_file_placement_cover, file: image, placement: article)
-    article.reload
-
-    render_inline(Folio::StructuredData::BodyComponent.new(record: article, breadcrumbs: []))
-
-    json = JSON.parse(page.find('script[type="application/ld+json"]', visible: false).text(:all))
-    article_data = json["@graph"].find { |item| item["@type"] == "Article" }
-
-    assert_equal "Wikipedia", article_data["image"]["creditText"]
-  end
-
   test "render article structured data has no image when article has no cover" do
     create_and_host_site
     article = create(:dummy_blog_article, published_at: Time.current)

--- a/test/components/folio/structured_data/body_component_test.rb
+++ b/test/components/folio/structured_data/body_component_test.rb
@@ -115,6 +115,36 @@ class Folio::StructuredData::BodyComponentTest < Folio::ComponentTest
     assert_not article_data["image"].key?("creditText")
   end
 
+  test "render article image creditText deduplicates matching author and attribution_source" do
+    create_and_host_site
+    article = create(:dummy_blog_article, published_at: Time.current)
+    image = create(:folio_file_image, author: "Reuters", attribution_source: "Reuters")
+    create(:folio_file_placement_cover, file: image, placement: article)
+    article.reload
+
+    render_inline(Folio::StructuredData::BodyComponent.new(record: article, breadcrumbs: []))
+
+    json = JSON.parse(page.find('script[type="application/ld+json"]', visible: false).text(:all))
+    article_data = json["@graph"].find { |item| item["@type"] == "Article" }
+
+    assert_equal "Reuters", article_data["image"]["creditText"]
+  end
+
+  test "render article image creditText falls back to file_list_source when author and attribution_source are blank" do
+    create_and_host_site
+    article = create(:dummy_blog_article, published_at: Time.current)
+    image = create(:folio_file_image, author: nil, attribution_source: nil, file_list_source: "Wikipedia")
+    create(:folio_file_placement_cover, file: image, placement: article)
+    article.reload
+
+    render_inline(Folio::StructuredData::BodyComponent.new(record: article, breadcrumbs: []))
+
+    json = JSON.parse(page.find('script[type="application/ld+json"]', visible: false).text(:all))
+    article_data = json["@graph"].find { |item| item["@type"] == "Article" }
+
+    assert_equal "Wikipedia", article_data["image"]["creditText"]
+  end
+
   test "render article structured data has no image when article has no cover" do
     create_and_host_site
     article = create(:dummy_blog_article, published_at: Time.current)


### PR DESCRIPTION
creditText improvements:
- pridano testy, a deduplicates matching `author` / `attribution_source` (e.g. `"Reuters / Reuters"` → `"Reuters"`)