### PR TITLE
fix(devise): render dev login button only when test creds work

### DIFF
--- a/app/cells/folio/devise/sessions/new/show.slim
+++ b/app/cells/folio/devise/sessions/new/show.slim
@@ -21,7 +21,7 @@
 
     = submit_button(f, t('.sign_in'), test_id: 'sign-in-form-submit-button')
 
-    - if ::Rails.env.development?
+    - if dev_login?
       button.btn.btn-warning.my-3 onclick="const form = this.closest('form'); for (const input of form.querySelectorAll('.form-control')) { input.value = 'test@test.test' }; form.submit();"
         ' #{t('.sign_in')} (test@test.test)
 

--- a/app/cells/folio/devise/sessions/new_cell.rb
+++ b/app/cells/folio/devise/sessions/new_cell.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Folio::Devise::Sessions::NewCell < Folio::Devise::ApplicationCell
+  DEV_LOGIN_CREDENTIAL = "test@test.test"
+
   def form(&block)
     opts = {
       url: controller.session_path(resource_name),
@@ -13,5 +15,12 @@ class Folio::Devise::Sessions::NewCell < Folio::Devise::ApplicationCell
     }
 
     simple_form_for(resource, opts, &block)
+  end
+
+  def dev_login?
+    return false unless ::Rails.env.development?
+
+    user = ::Folio::User.find_by(email: DEV_LOGIN_CREDENTIAL)
+    user&.valid_password?(DEV_LOGIN_CREDENTIAL) || false
   end
 end


### PR DESCRIPTION
## Summary

Renders the dev-only auto-fill login button on `/users/sign_in` only when a `test@test.test` user exists **and** `valid_password?("test@test.test")` returns true. Previously rendered in every `Rails.env.development?` environment regardless of whether the credentials actually worked, forcing host apps (e.g. smilemusic, whose seed uses a different password) to hide it via CSS.

Náhrada za uzavřený #607 — implementuje detekci uživatele/hesla podle návrhu @mreq místo opt-in přes config.

## Test plan

- [x] Ověřeno v `smilemusic` lokálně (folio jako path gem):
  - heslo `test@test.test` → tlačítko se renderuje
  - seed heslo `Test123@test.test` → tlačítko se nerenderuje
- [x] V `production`/`staging` se tlačítko nerenderuje (early return na `Rails.env.development?`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)