### PR TITLE
Devel 35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **`Folio::File.default_file_order` scope** — exposes the canonical newest-first ordering (`created_at DESC, id DESC`) used by console file listings and pickers, including a deterministic `id` tiebreaker for stable pagination.
+
 ### Changed
 
+- **Default file search results are sorted newest first** — search results in `Folio::Console::FileControllerBase#index` and `Folio::Console::Api::FileControllerBase#index_json` now apply `created_at DESC, id DESC` after `filter_by_params`, so the newest uploads appear first regardless of which filter combination is active.
 - **`ImageObject` `creditText`**: now uses `Folio::File#credit_text`, deduplicating matching `author` / `attribution_source` (e.g. `"Reuters / Reuters"` → `"Reuters"`) and falling back to `file_list_source` when both are
   blank.
 

--- a/app/controllers/concerns/folio/console/api/file_controller_base.rb
+++ b/app/controllers/concerns/folio/console/api/file_controller_base.rb
@@ -414,10 +414,16 @@ module Folio::Console::Api::FileControllerBase
     end
 
     def index_json
-      pagination, records = pagy(folio_console_records.ordered, items: 60)
+      pagination, records = pagy(index_json_records, items: 60)
       meta = meta_from_pagy(pagination).merge(human_type: @klass.human_type)
 
       json_from_records(records, Folio::Console::FileSerializer, meta:)
+    end
+
+    def index_json_records
+      return folio_console_records if @sorted_by_param
+
+      folio_console_records.default_file_order
     end
 
     def index_cache_key

--- a/app/controllers/concerns/folio/console/file_controller_base.rb
+++ b/app/controllers/concerns/folio/console/file_controller_base.rb
@@ -17,6 +17,8 @@ module Folio::Console::FileControllerBase
     @turbo_frame_id = @klass.console_turbo_frame_id(modal: action_name == "index_for_modal",
                                                     picker: action_name == "index_for_picker")
 
+    apply_default_file_order
+
     super
   end
 
@@ -145,6 +147,17 @@ module Folio::Console::FileControllerBase
 
     def index_pagy_items_per_page
       PAGY_ITEMS
+    end
+
+    def apply_default_file_order
+      return if @sorted_by_param
+
+      records = folio_console_records
+      return unless records
+
+      name = folio_console_record_variable_name(plural: true)
+      instance_variable_set(name, records.default_file_order)
+      @sorted_by_param = :default_file_order
     end
 
     def message_bus_broadcast_update

--- a/app/models/folio/file.rb
+++ b/app/models/folio/file.rb
@@ -98,7 +98,8 @@ class Folio::File < Folio::ApplicationRecord
   validate :validate_attribution_and_texts_if_needed
 
   # Scopes
-  scope :ordered, -> { order(created_at: :desc) }
+  scope :ordered, -> { order(created_at: :desc, id: :desc) }
+  scope :default_file_order, -> { reorder(arel_table[:created_at].desc, arel_table[:id].desc) }
 
   scope :by_placement, -> (placement_title) { order(created_at: :desc) }
 

--- a/test/controllers/folio/console/api/file_controller_base_test.rb
+++ b/test/controllers/folio/console/api/file_controller_base_test.rb
@@ -103,6 +103,35 @@ class Folio::Console::Api::FileControllerBaseTest < Folio::Console::BaseControll
       assert_includes reload_url, "page=2", "reload_url should preserve page"
     end
 
+    if %w[image video].include?(klass.human_type)
+      test "#{klass} - index with by_file_name sorts newest first" do
+        created_at = Time.zone.parse("2026-04-29 14:00:00")
+        query = "cs279api#{klass.human_type}"
+        older = create(klass.model_name.singular,
+                       site: @site,
+                       file_name: query,
+                       created_at: created_at - 1.hour)
+        lower_id = create(klass.model_name.singular,
+                          site: @site,
+                          file_name: "#{query}-lower",
+                          created_at:)
+        higher_id = create(klass.model_name.singular,
+                           site: @site,
+                           file_name: "#{query}-higher",
+                           created_at:)
+        expected_ids = [higher_id.id, lower_id.id, older.id]
+
+        get url_for([:console, :api, klass, format: :json]), params: { by_file_name: query }
+
+        actual_ids = response.parsed_body["data"]
+                             .map { |record| record["id"].to_i }
+                             .select { |id| expected_ids.include?(id) }
+
+        assert_response :success
+        assert_equal expected_ids, actual_ids
+      end
+    end
+
     test "#{klass} - pagination preserves explicit request_path after picker upload refresh" do
       create_list(klass.model_name.singular, Folio::Console::FileControllerBase::PAGY_ITEMS + 1)
 

--- a/test/controllers/folio/console/files_controller_by_query_test.rb
+++ b/test/controllers/folio/console/files_controller_by_query_test.rb
@@ -41,6 +41,70 @@ class Folio::Console::FilesControllerByQueryTest < Folio::Console::BaseControlle
     assert_response :success
   end
 
+  test "image index with by_query sorts newest first" do
+    created_at = Time.zone.parse("2026-04-29 12:00:00")
+    older = create(:folio_file_image, site: @site, slug: "cs279-html-image-older", created_at: created_at - 1.hour)
+    lower_id = create(:folio_file_image, site: @site, slug: "cs279-html-image-lower", created_at:)
+    higher_id = create(:folio_file_image, site: @site, slug: "cs279-html-image-higher", created_at:)
+    expected_ids = [higher_id.id, lower_id.id, older.id]
+
+    get url_for([:console, Folio::File::Image]), params: { by_query: "cs279-html-image" }
+
+    actual_ids = Nokogiri::HTML(response.body)
+                         .css(".f-file-list-file")
+                         .filter_map { |node| node["data-f-file-list-file-id-value"].presence&.to_i }
+                         .select { |id| expected_ids.include?(id) }
+
+    assert_response :success
+    assert_equal expected_ids, actual_ids
+  end
+
+  test "video index with by_query sorts newest first" do
+    created_at = Time.zone.parse("2026-04-29 13:00:00")
+    older = create(:folio_file_video, site: @site, slug: "cs279-html-video-older", created_at: created_at - 1.hour)
+    lower_id = create(:folio_file_video, site: @site, slug: "cs279-html-video-lower", created_at:)
+    higher_id = create(:folio_file_video, site: @site, slug: "cs279-html-video-higher", created_at:)
+    expected_ids = [higher_id.id, lower_id.id, older.id]
+
+    get url_for([:console, Folio::File::Video]), params: { by_query: "cs279-html-video" }
+
+    actual_ids = Nokogiri::HTML(response.body)
+                         .css(".f-file-list-file")
+                         .filter_map { |node| node["data-f-file-list-file-id-value"].presence&.to_i }
+                         .select { |id| expected_ids.include?(id) }
+
+    assert_response :success
+    assert_equal expected_ids, actual_ids
+  end
+
+  test "image index sorts newest first when by_query is combined with another filter" do
+    created_at = Time.zone.parse("2026-04-29 15:00:00")
+    older = create(:folio_file_image,
+                   site: @site,
+                   slug: "cs279-combined-older",
+                   created_at: created_at - 1.hour,
+                   created_by_folio_user_id: @superadmin.id)
+    newer = create(:folio_file_image,
+                   site: @site,
+                   slug: "cs279-combined-newer",
+                   created_at:,
+                   created_by_folio_user_id: @superadmin.id)
+    expected_ids = [newer.id, older.id]
+
+    get url_for([:console, Folio::File::Image]), params: {
+      by_query: "cs279-combined",
+      created_by_current_user: "1",
+    }
+
+    actual_ids = Nokogiri::HTML(response.body)
+                         .css(".f-file-list-file")
+                         .filter_map { |node| node["data-f-file-list-file-id-value"].presence&.to_i }
+                         .select { |id| expected_ids.include?(id) }
+
+    assert_response :success
+    assert_equal expected_ids, actual_ids
+  end
+
   test "by_query works for document files" do
     get url_for([:console, Folio::File::Document]), params: { by_query: "Pardubice" }
     assert_response :success

--- a/test/models/folio/file_test.rb
+++ b/test/models/folio/file_test.rb
@@ -76,6 +76,72 @@ class Folio::FileTest < ActiveSupport::TestCase
     assert_equal [file2], Folio::File.by_file_name("foo-bar")
   end
 
+  test "ordered sorts by newest created_at with id tiebreaker" do
+    created_at = Time.zone.parse("2026-04-29 10:00:00")
+    older = create(:folio_file_image, created_at: created_at - 1.hour)
+    lower_id = create(:folio_file_image, created_at:)
+    higher_id = create(:folio_file_image, created_at:)
+
+    records = Folio::File::Image.where(id: [older.id, lower_id.id, higher_id.id]).ordered
+
+    assert_equal [higher_id, lower_id, older], records.to_a
+  end
+
+  test "default_file_order replaces previous order" do
+    created_at = Time.zone.parse("2026-04-29 10:30:00")
+    older = create(:folio_file_image, created_at: created_at - 1.hour)
+    lower_id = create(:folio_file_image, created_at:)
+    higher_id = create(:folio_file_image, created_at:)
+
+    records = Folio::File::Image.where(id: [older.id, lower_id.id, higher_id.id])
+                                .order(id: :asc)
+                                .default_file_order
+
+    assert_equal [higher_id, lower_id, older], records.to_a
+  end
+
+  test "by_query can be ordered newest first for images and videos" do
+    created_at = Time.zone.parse("2026-04-29 11:00:00")
+    older_image = create(:folio_file_image, slug: "cs279-query-image-older", created_at: created_at - 1.hour)
+    newer_image = create(:folio_file_image, slug: "cs279-query-image-newer", created_at:)
+    older_video = create(:folio_file_video, slug: "cs279-query-video-older", created_at: created_at - 1.hour)
+    newer_video = create(:folio_file_video, slug: "cs279-query-video-newer", created_at:)
+
+    image_records = Folio::File::Image.by_query("cs279-query-image")
+                                      .where(id: [older_image.id, newer_image.id])
+                                      .ordered
+    video_records = Folio::File::Video.by_query("cs279-query-video")
+                                      .where(id: [older_video.id, newer_video.id])
+                                      .ordered
+
+    assert_equal [newer_image, older_image], image_records.to_a
+    assert_equal [newer_video, older_video], video_records.to_a
+  end
+
+  test "ordered pagination is stable across pages with identical created_at" do
+    created_at = Time.zone.parse("2026-04-29 09:00:00")
+    files = Array.new(4) { create(:folio_file_image, created_at:) }
+    ids = files.map(&:id)
+
+    scope = Folio::File::Image.where(id: ids).ordered
+
+    page1 = scope.limit(2).offset(0).to_a
+    page2 = scope.limit(2).offset(2).to_a
+
+    assert_equal 2, page1.size
+    assert_equal 2, page2.size
+    assert_empty (page1 & page2), "no record should appear on both pages"
+    assert_equal ids.sort, (page1 + page2).map(&:id).sort, "every record should appear exactly once"
+    assert_equal ids.sort.reverse, (page1 + page2).map(&:id), "pagination order must follow id DESC tiebreaker"
+  end
+
+  test "created_at column is NOT NULL on folio_files" do
+    column = Folio::File.columns_hash["created_at"]
+
+    assert column, "folio_files.created_at must exist"
+    assert_not column.null
+  end
+
   test "have 4 basic states" do
     file = Folio::File.new
     assert_equal [:unprocessed, :processing, :ready, :processing_failed], file.class.all_state_names


### PR DESCRIPTION
* fix(console): default file search results to newest first Apply created_at DESC, id DESC ordering after filter_by_params in
 both HTML and JSON file controllers so newest uploads appear first regardless of active filter combination. User sort still wins via @sorted_by_param. Adds Folio::File.default_file_order scope.