### PR TITLE
File visibility from published usage + reliable file deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`Folio::File#used_in_published_content?`** — live check whether a file is used in at least one published piece of content (unwraps atoms to the parent record, respects owner `published?` incl. `published_at`). Intended for host apps that derive public visibility of standalone file pages from usage.
+- **Console file usage list** now shows orphaned placements (owner deleted) with the option to remove them, plus a published/unpublished badge for each usage. The usage section is expanded when deletion is blocked.
+- **`folio:files:recalculate_placement_counts`** and **`folio:files:report_videos_without_published_usage`** rake tasks.
+
 ### Fixed
 
 - **Console remote selects**: Match Select2 arrow and fade overlays to the disabled selection background so long values no longer show white patches.
@@ -10,6 +16,8 @@ All notable changes to this project will be documented in this file.
 - **Console validation box Tiptap focus**: Focus the visible Tiptap editor after scrolling to invalid Tiptap content and skip the hidden-input danger blink.
 - **AI current form snapshots**: Keep full atom payloads under `record_class.atom_keys` instead of only atom `data` leaves, so host apps using direct atom attributes can build prompt context from unsaved atom-backed forms.
 - **Console publishable inputs**: Treat open-ended `Folio::Publishable::Within` date ranges as restricted when the present start or end date excludes the current time, so future `published_from` values no longer render as active when `published_until` is blank.
+- A stale `file_placements_count` no longer blocks file deletion — the model destroy guard, console file detail and API destroy verify usage with a live query (`Folio::File#live_indestructible_reason`). File list views still use the cheap counter.
+- FriendlyId slug history cleanup and CRA media cleanup on file destroy are now covered by tests (both behaviors already existed).
 
 ## [7.7.0] - 2026-06-02
 

--- a/app/components/folio/console/files/show/file_placements_component.rb
+++ b/app/components/folio/console/files/show/file_placements_component.rb
@@ -42,7 +42,9 @@ class Folio::Console::Files::Show::FilePlacementsComponent < Folio::Console::App
     end
 
     def orphaned_type(file_placement)
-      file_placement.placement_title_type.presence || file_placement.type
+      file_placement.placement_title_type.presence&.safe_constantize&.model_name&.human ||
+        file_placement.type.constantize.model_name.human ||
+        file_placement.type
     end
 
     def placement_label(placement)

--- a/app/components/folio/console/files/show/file_placements_component.rb
+++ b/app/components/folio/console/files/show/file_placements_component.rb
@@ -13,6 +13,38 @@ class Folio::Console::Files::Show::FilePlacementsComponent < Folio::Console::App
       @pagy, @file_placements = pagy(@file.file_placements.includes(:placement).order(created_at: :desc), items: 20)
     end
 
+    def rows
+      @file_placements.map do |file_placement|
+        owner = unwrap_owner(file_placement.placement)
+
+        {
+          file_placement:,
+          owner:,
+          orphaned: owner.nil?,
+          published: owner_published(owner),
+          action: owner ? placement_action(owner) : { type: :none },
+        }
+      end
+    end
+
+    def unwrap_owner(owner)
+      owner.is_a?(Folio::Atom::Base) ? owner.placement : owner
+    end
+
+    # true / false / nil (nil = owner has no published concept or is orphaned)
+    def owner_published(owner)
+      return nil if owner.nil? || !owner.respond_to?(:published?)
+      owner.published?
+    end
+
+    def orphaned_label(file_placement)
+      file_placement.placement_title.presence || "##{file_placement.id}"
+    end
+
+    def orphaned_type(file_placement)
+      file_placement.placement_title_type.presence || file_placement.type
+    end
+
     def placement_label(placement)
       placement.try(:to_label) || "##{placement.id}"
     end

--- a/app/components/folio/console/files/show/file_placements_component.rb
+++ b/app/components/folio/console/files/show/file_placements_component.rb
@@ -43,7 +43,7 @@ class Folio::Console::Files::Show::FilePlacementsComponent < Folio::Console::App
 
     def orphaned_type(file_placement)
       file_placement.placement_title_type.presence&.safe_constantize&.model_name&.human ||
-        file_placement.type.constantize.model_name.human ||
+        file_placement.type.safe_constantize&.model_name&.human ||
         file_placement.type
     end
 

--- a/app/components/folio/console/files/show/file_placements_component.sass
+++ b/app/components/folio/console/files/show/file_placements_component.sass
@@ -1,4 +1,8 @@
 .f-c-files-show-file-placements
+  &__row
+    &--orphaned
+      color: $text-muted
+
   &__td
     vertical-align: middle
 

--- a/app/components/folio/console/files/show/file_placements_component.slim
+++ b/app/components/folio/console/files/show/file_placements_component.slim
@@ -8,46 +8,79 @@
           th.f-c-files-show-file-placements__td = t('.th/type')
           th.f-c-files-show-file-placements__td = t('.th/placement_type')
           th.f-c-files-show-file-placements__td = t('.th/placement_label')
+          th.f-c-files-show-file-placements__td = t('.th/published')
           th.f-c-files-show-file-placements__td = t('.th/created_at')
           th.f-c-files-show-file-placements__td
 
-      - @file_placements.each do |file_placement|
-        - next if file_placement.placement.blank?
-        - placement = file_placement.placement.is_a?(Folio::Atom::Base) ? file_placement.placement.placement : file_placement.placement
-        - action = placement_action(placement)
+      - rows.each do |row|
+        - file_placement = row[:file_placement]
 
-        tr.small
-          td.f-c-files-show-file-placements__td
-            = placement.model_name.human
+        - if row[:orphaned]
+          tr[
+            class="small"
+            class="f-c-files-show-file-placements__row"
+            class="f-c-files-show-file-placements__row--orphaned"
+          ]
+            td.f-c-files-show-file-placements__td
+              = t('.orphaned')
 
-            - if file_placement.placement.is_a?(Folio::Atom::Base)
-              .text-muted
-                ' (#{t('.in_atom')})
+            td.f-c-files-show-file-placements__td
+              = orphaned_type(file_placement)
 
-          td.f-c-files-show-file-placements__td
-            = placement.model_name.human
+            td.f-c-files-show-file-placements__td
+              = orphaned_label(file_placement)
 
-          td.f-c-files-show-file-placements__td
-            - if action[:url]
-              a href=action[:url] target="_href"
-                = placement_label(placement)
-            - else
-              = placement_label(placement)
+            td.f-c-files-show-file-placements__td
+              span.text-muted —
 
-          td.f-c-files-show-file-placements__td
-            = l(file_placement.created_at, format: :console_short)
+            td.f-c-files-show-file-placements__td
+              = l(file_placement.created_at, format: :console_short)
 
-          td.f-c-files-show-file-placements__td
-            - if action[:url]
-              a.f-c-files-show-file-placements__action[
-                href=action[:url]
-                target="_blank"
-                class="text-reset"
-              ]
-                - if action[:type] == :show
-                  = folio_icon(:eye, height: 16)
-                - else
-                  = folio_icon(:edit_box, height: 16)
+            td.f-c-files-show-file-placements__td.f-c-files-show-file-placements__destroy-cell
+        - else
+          - owner = row[:owner]
+          - action = row[:action]
+
+          tr.small.f-c-files-show-file-placements__row
+            td.f-c-files-show-file-placements__td
+              = owner.model_name.human
+
+              - if file_placement.placement.is_a?(Folio::Atom::Base)
+                .text-muted
+                  ' (#{t('.in_atom')})
+
+            td.f-c-files-show-file-placements__td
+              = owner.model_name.human
+
+            td.f-c-files-show-file-placements__td
+              - if action[:url]
+                a href=action[:url] target="_href"
+                  = placement_label(owner)
+              - else
+                = placement_label(owner)
+
+            td.f-c-files-show-file-placements__td
+              - if row[:published] == true
+                span.text-success = t('.published')
+              - elsif row[:published] == false
+                span.text-danger = t('.unpublished')
+              - else
+                span.text-muted —
+
+            td.f-c-files-show-file-placements__td
+              = l(file_placement.created_at, format: :console_short)
+
+            td.f-c-files-show-file-placements__td
+              - if action[:url]
+                a.f-c-files-show-file-placements__action[
+                  href=action[:url]
+                  target="_blank"
+                  class="text-reset"
+                ]
+                  - if action[:type] == :show
+                    = folio_icon(:eye, height: 16)
+                  - else
+                    = folio_icon(:edit_box, height: 16)
 
     - if @pagy && @pagy.pages > 1
       = render(Folio::Console::Ui::PagyComponent.new(pagy: @pagy))

--- a/app/components/folio/console/files/show/file_placements_component.slim
+++ b/app/components/folio/console/files/show/file_placements_component.slim
@@ -16,11 +16,7 @@
         - file_placement = row[:file_placement]
 
         - if row[:orphaned]
-          tr[
-            class="small"
-            class="f-c-files-show-file-placements__row"
-            class="f-c-files-show-file-placements__row--orphaned"
-          ]
+          tr.small.f-c-files-show-file-placements__row.f-c-files-show-file-placements__row--orphaned
             td.f-c-files-show-file-placements__td
               = t('.orphaned')
 

--- a/app/components/folio/console/files/show/file_placements_component.slim
+++ b/app/components/folio/console/files/show/file_placements_component.slim
@@ -33,6 +33,10 @@
               = l(file_placement.created_at, format: :console_short)
 
             td.f-c-files-show-file-placements__td.f-c-files-show-file-placements__destroy-cell
+              = link_to t('.destroy_orphan'),
+                        controller.folio.console_file_placement_path(file_placement),
+                        class: "btn btn-sm btn-danger",
+                        data: { method: :delete, confirm: t('.destroy_orphan_confirm') }
         - else
           - owner = row[:owner]
           - action = row[:action]

--- a/app/components/folio/console/files/show_component.rb
+++ b/app/components/folio/console/files/show_component.rb
@@ -40,6 +40,11 @@ class Folio::Console::Files::ShowComponent < Folio::Console::ApplicationComponen
     }
   end
 
+  def live_indestructible_reason
+    return @live_indestructible_reason if defined?(@live_indestructible_reason)
+    @live_indestructible_reason = @file.live_indestructible_reason
+  end
+
   def destroy_button_model
     h = {
       label: t(".destroy"),
@@ -47,7 +52,7 @@ class Folio::Console::Files::ShowComponent < Folio::Console::ApplicationComponen
       variant: :danger,
     }
 
-    if @file.indestructible_reason
+    if live_indestructible_reason
       h[:disabled] = true
     else
       h[:data] = stimulus_action({ click: "onDestroyClick" }, { url: url_for([:console, :api, @file]) })

--- a/app/components/folio/console/files/show_component.slim
+++ b/app/components/folio/console/files/show_component.slim
@@ -27,8 +27,8 @@
                 = render(Folio::Console::Ui::ButtonComponent.new(**replace_button_model))
 
           - if can_now?(:destroy, @file)
-            - if @file.indestructible_reason
-              .f-c-files-show__button-tooltip data=stimulus_tooltip(@file.indestructible_reason)
+            - if live_indestructible_reason
+              .f-c-files-show__button-tooltip data=stimulus_tooltip(live_indestructible_reason)
                 = render(Folio::Console::Ui::ButtonComponent.new(**destroy_button_model))
             - else
               = render(Folio::Console::Ui::ButtonComponent.new(**destroy_button_model))

--- a/app/components/folio/console/files/show_component.slim
+++ b/app/components/folio/console/files/show_component.slim
@@ -96,7 +96,7 @@
             = render(Folio::Console::Files::Show::MetadataComponent.new(file: @file))
 
         = render(Folio::Console::Ui::CollapsibleComponent.new(title: t('.title/usage', count: @file.file_placements_count),
-                                                              collapsed: controller.action_name != "file_placements"))
+                                                              collapsed: controller.action_name != "file_placements" && live_indestructible_reason.nil?))
           = render(Folio::Console::Files::Show::FilePlacementsComponent.new(file: @file))
 
   - if @file.class.human_type == "image"

--- a/app/controllers/concerns/folio/console/api/file_controller_base.rb
+++ b/app/controllers/concerns/folio/console/api/file_controller_base.rb
@@ -56,12 +56,7 @@ module Folio::Console::Api::FileControllerBase
   end
 
   def destroy
-    indestructible_reason = folio_console_record.indestructible_reason
-    indestructible_reason ||= if folio_console_record.file_placements.exists?
-      I18n.t("folio.file.cannot_destroy_file_with_placements")
-    end
-
-    if indestructible_reason
+    if (indestructible_reason = folio_console_record.live_indestructible_reason)
       render json: { errors: [
         status: 422,
         title: "ActiveRecord::RecordNotDestroyed",

--- a/app/controllers/folio/console/file_placements_controller.rb
+++ b/app/controllers/folio/console/file_placements_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Folio::Console::FilePlacementsController < Folio::Console::BaseController
+  def destroy
+    placement = Folio::FilePlacement::Base.find(params[:id])
+    authorize!(:destroy, placement.file)
+
+    # only orphaned usage records may be removed from here - live content is
+    # unlinked by editing the owning record
+    raise ActiveRecord::RecordNotFound if placement.placement.present?
+
+    placement.destroy!
+
+    redirect_back fallback_location: url_for([:console, placement.file]),
+                  flash: { success: t("folio.console.file_placements.destroyed") }
+  end
+end

--- a/app/models/folio/file.rb
+++ b/app/models/folio/file.rb
@@ -348,10 +348,23 @@ class Folio::File < Folio::ApplicationRecord
     "#{hours.to_s.rjust(2, '0')}:#{minutes.to_s.rjust(2, '0')}:#{seconds.to_s.rjust(2, '0')}.#{centiseconds.to_s.rjust(2, '0')}"
   end
 
+  # Counter-cache based — cheap, called per row in file lists; may be stale.
+  # Overridable in host apps. Destroy paths use #live_indestructible_reason.
   def indestructible_reason
     return nil if file_placements_count == 0
     return nil if file_placements_count.nil?
     I18n.t("folio.file.cannot_destroy_file_with_placements")
+  end
+
+  # Accurate variant for destroy paths and the file detail — re-verifies the
+  # placements message with a live query so a stale counter cannot block
+  # deletion. Host-app reasons other than the placements message pass through.
+  def live_indestructible_reason
+    reason = indestructible_reason
+    placements_message = I18n.t("folio.file.cannot_destroy_file_with_placements")
+    return reason if reason.present? && reason != placements_message
+
+    placements_message if file_placements.exists?
   end
 
   def file_list_count
@@ -501,8 +514,7 @@ class Folio::File < Folio::ApplicationRecord
     end
 
     def check_usage_before_destroy
-      throw(:abort) if indestructible_reason.present?
-      throw(:abort) if file_placements.exists?
+      throw(:abort) if live_indestructible_reason.present?
     end
 
     def set_file_track_duration

--- a/app/models/folio/file.rb
+++ b/app/models/folio/file.rb
@@ -418,6 +418,8 @@ class Folio::File < Folio::ApplicationRecord
   # piece of content. Unlike +published_usage_count+ (licensing usage limits,
   # see #calculate_published_usage_count) this unwraps atoms to their parent
   # record and uses the owner's #published? (incl. published_at semantics).
+  # Atom parents are loaded one query each — the includes(:placement) below
+  # does not cover the second hop.
   # Single-record use only — for collections build an SQL scope instead.
   def used_in_published_content?
     file_placements.includes(:placement).find_each(batch_size: 100) do |file_placement|

--- a/app/models/folio/file.rb
+++ b/app/models/folio/file.rb
@@ -414,6 +414,26 @@ class Folio::File < Folio::ApplicationRecord
     # to be overriden in main_app should be needed
   end
 
+  # Live visibility check: true if the file is used in at least one published
+  # piece of content. Unlike +published_usage_count+ (licensing usage limits,
+  # see #calculate_published_usage_count) this unwraps atoms to their parent
+  # record and uses the owner's #published? (incl. published_at semantics).
+  # Single-record use only — for collections build an SQL scope instead.
+  def used_in_published_content?
+    file_placements.includes(:placement).find_each(batch_size: 100) do |file_placement|
+      owner = file_placement.placement
+      owner = owner.placement if owner.is_a?(Folio::Atom::Base)
+      next if owner.nil?
+      return true if !owner.respond_to?(:published?) || owner.published?
+    end
+
+    false
+  end
+
+  # NOTE: intentionally different semantics from #used_in_published_content?
+  # (visibility): here atom-owned placements count as published and only the
+  # raw `published` column is checked. Consumed by licensing usage limits
+  # (Folio::File::HasUsageConstraints) — do not change without checking those.
   def calculate_published_usage_count
     placement_types = file_placements.distinct.pluck(:placement_type)
     return 0 if placement_types.empty?

--- a/config/locales/console/file_placements.cs.yml
+++ b/config/locales/console/file_placements.cs.yml
@@ -3,6 +3,8 @@ cs:
   folio:
     console:
       file_placements:
+        destroyed: Záznam použití byl odstraněn.
+
         multi_picker_fields_component:
           add_embed: Přidat Embed (HTML kód)
           select/image: Vybrat obrázek

--- a/config/locales/console/file_placements.en.yml
+++ b/config/locales/console/file_placements.en.yml
@@ -3,6 +3,8 @@ en:
   folio:
     console:
       file_placements:
+        destroyed: Usage record removed.
+
         multi_picker_fields_component:
           add_embed: Add Embed (HTML code)
           select/image: Select image

--- a/config/locales/console/files.cs.yml
+++ b/config/locales/console/files.cs.yml
@@ -44,8 +44,12 @@ cs:
             th/type: Typ použití
             th/placement_type: Typ záznamu
             th/placement_label: Záznam
+            th/published: Stav
             th/created_at: Vytvořeno
             in_atom: kapitola obsahu
+            orphaned: Smazaný obsah
+            published: Publikováno
+            unpublished: Nepublikováno
 
           thumbnails_component:
             title: Verze a velikosti

--- a/config/locales/console/files.cs.yml
+++ b/config/locales/console/files.cs.yml
@@ -50,6 +50,8 @@ cs:
             orphaned: Smazaný obsah
             published: Publikováno
             unpublished: Nepublikováno
+            destroy_orphan: Odstranit záznam
+            destroy_orphan_confirm: Opravdu odstranit osiřelý záznam použití?
 
           thumbnails_component:
             title: Verze a velikosti

--- a/config/locales/console/files.en.yml
+++ b/config/locales/console/files.en.yml
@@ -50,6 +50,8 @@ en:
             orphaned: Deleted content
             published: Published
             unpublished: Unpublished
+            destroy_orphan: Remove record
+            destroy_orphan_confirm: Really remove the orphaned usage record?
             no_thumbnails_yet: No versions generated yet
 
           thumbnails_component:

--- a/config/locales/console/files.en.yml
+++ b/config/locales/console/files.en.yml
@@ -44,8 +44,12 @@ en:
             th/type: Usage type
             th/placement_type: Record type
             th/placement_label: Record
+            th/published: State
             th/created_at: Created at
             in_atom: content chapter
+            orphaned: Deleted content
+            published: Published
+            unpublished: Unpublished
             no_thumbnails_yet: No versions generated yet
 
           thumbnails_component:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,8 @@ Folio::Engine.routes.draw do
         end
       end
 
+      resources :file_placements, only: %i[destroy]
+
       if ::Rails.application.config.folio_leads_from_component_class_name
         resources :leads, only: %i[index show edit update destroy] do
           collection { post :mass_handle }

--- a/lib/tasks/folio_file_usage.rake
+++ b/lib/tasks/folio_file_usage.rake
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+namespace :folio do
+  namespace :files do
+    desc "Recalculate stale placement counters. DRY_RUN=1 lists ids only. ALL_VIDEOS=1 also recalcs every video."
+    task recalculate_placement_counts: :environment do
+      mismatched_ids = Folio::File.where(
+        "folio_files.file_placements_count <> " \
+        "(SELECT COUNT(*) FROM folio_file_placements fp WHERE fp.file_id = folio_files.id)"
+      ).pluck(:id)
+
+      puts "Files with stale file_placements_count: #{mismatched_ids.size}"
+
+      if ENV["DRY_RUN"].present?
+        puts mismatched_ids.inspect
+      else
+        Folio::File.where(id: mismatched_ids).find_each(&:update_file_placements_counts!)
+        puts "Recalculated #{mismatched_ids.size} files."
+      end
+
+      if ENV["ALL_VIDEOS"].present? && ENV["DRY_RUN"].blank?
+        count = 0
+
+        Folio::File::Video.find_each do |video|
+          video.update_file_placements_counts!
+          count += 1
+        end
+
+        puts "Recalculated all #{count} videos."
+      end
+    end
+
+    desc "CSV list of videos with no published usage (their public pages return 404)"
+    task report_videos_without_published_usage: :environment do
+      count = 0
+      puts "id;slug;file_name"
+
+      Folio::File::Video.find_each do |video|
+        next if video.used_in_published_content?
+        count += 1
+        puts [video.id, video.slug, video.file_name].join(";")
+      end
+
+      warn "Total without published usage: #{count}"
+    end
+  end
+end

--- a/test/components/folio/console/files/show/file_placements_component_test.rb
+++ b/test/components/folio/console/files/show/file_placements_component_test.rb
@@ -20,4 +20,47 @@ class Folio::Console::Files::Show::FilePlacementsComponentTest < Folio::Console:
     assert_selector(".f-c-files-show-file-placements")
     assert_selector(".f-c-files-show-file-placements__table")
   end
+
+  def test_render_orphaned_placement
+    video = create(:folio_file_video)
+    Folio::FilePlacement::VideoCover.create!(placement: nil, file: video)
+
+    render_inline(Folio::Console::Files::Show::FilePlacementsComponent.new(file: video))
+
+    assert_selector(".f-c-files-show-file-placements__row--orphaned")
+    assert_selector(".f-c-files-show-file-placements__row--orphaned",
+                    text: I18n.t("folio.console.files.show.file_placements_component.orphaned"))
+  end
+
+  def test_render_published_owner_state
+    video = create(:folio_file_video)
+    page = create(:folio_page, published: true)
+    Folio::FilePlacement::VideoCover.create!(placement: page, file: video)
+
+    render_inline(Folio::Console::Files::Show::FilePlacementsComponent.new(file: video))
+
+    assert_selector(".f-c-files-show-file-placements__row .text-success",
+                    text: I18n.t("folio.console.files.show.file_placements_component.published"))
+    assert_no_selector(".f-c-files-show-file-placements__row--orphaned")
+  end
+
+  def test_render_unpublished_owner_state
+    video = create(:folio_file_video)
+    page = create(:folio_page, published: false)
+    Folio::FilePlacement::VideoCover.create!(placement: page, file: video)
+
+    render_inline(Folio::Console::Files::Show::FilePlacementsComponent.new(file: video))
+
+    assert_selector(".f-c-files-show-file-placements__row .text-danger",
+                    text: I18n.t("folio.console.files.show.file_placements_component.unpublished"))
+  end
+
+  def test_render_owner_label_for_regular_placement
+    file_placement = create(:folio_file_placement_cover)
+
+    render_inline(Folio::Console::Files::Show::FilePlacementsComponent.new(file: file_placement.file))
+
+    assert_selector(".f-c-files-show-file-placements__row",
+                    text: file_placement.placement.to_label)
+  end
 end

--- a/test/components/folio/console/files/show/file_placements_component_test.rb
+++ b/test/components/folio/console/files/show/file_placements_component_test.rb
@@ -32,6 +32,21 @@ class Folio::Console::Files::Show::FilePlacementsComponentTest < Folio::Console:
                     text: I18n.t("folio.console.files.show.file_placements_component.orphaned"))
   end
 
+  def test_render_orphaned_placement_with_title_snapshot
+    video = create(:folio_file_video)
+    Folio::FilePlacement::VideoCover.create!(placement: nil,
+                                             file: video,
+                                             placement_title: "Folio::Page - Smazaná stránka",
+                                             placement_title_type: "Folio::Page")
+
+    render_inline(Folio::Console::Files::Show::FilePlacementsComponent.new(file: video))
+
+    assert_selector(".f-c-files-show-file-placements__row--orphaned",
+                    text: "Folio::Page - Smazaná stránka")
+    assert_selector(".f-c-files-show-file-placements__row--orphaned",
+                    text: Folio::Page.model_name.human)
+  end
+
   def test_render_published_owner_state
     video = create(:folio_file_video)
     page = create(:folio_page, published: true)

--- a/test/components/folio/console/files/show/file_placements_component_test.rb
+++ b/test/components/folio/console/files/show/file_placements_component_test.rb
@@ -32,6 +32,24 @@ class Folio::Console::Files::Show::FilePlacementsComponentTest < Folio::Console:
                     text: I18n.t("folio.console.files.show.file_placements_component.orphaned"))
   end
 
+  def test_render_destroy_button_for_orphaned_placement_only
+    video = create(:folio_file_video)
+    page = create(:folio_page, published: true)
+    orphaned = Folio::FilePlacement::VideoCover.create!(placement: nil, file: video)
+    Folio::FilePlacement::VideoCover.create!(placement: page, file: video)
+
+    render_inline(Folio::Console::Files::Show::FilePlacementsComponent.new(file: video))
+
+    assert_selector(".f-c-files-show-file-placements__destroy-cell a[data-method='delete']",
+                    text: I18n.t("folio.console.files.show.file_placements_component.destroy_orphan"),
+                    count: 1)
+    assert_selector(".f-c-files-show-file-placements__row--orphaned " \
+                    ".f-c-files-show-file-placements__destroy-cell " \
+                    "a[href$='/console/file_placements/#{orphaned.id}']")
+    assert_no_selector(".f-c-files-show-file-placements__row:not(.f-c-files-show-file-placements__row--orphaned) " \
+                       "a[data-method='delete']")
+  end
+
   def test_render_orphaned_placement_with_title_snapshot
     video = create(:folio_file_video)
     Folio::FilePlacement::VideoCover.create!(placement: nil,

--- a/test/controllers/folio/console/api/file_controller_base_test.rb
+++ b/test/controllers/folio/console/api/file_controller_base_test.rb
@@ -5,6 +5,13 @@ require "test_helper"
 class Folio::Console::Api::FileControllerBaseTest < Folio::Console::BaseControllerTest
   attr_reader :site
 
+  FILE_PLACEMENT_KLASSES = {
+    "Folio::File::Document" => Folio::FilePlacement::Document,
+    "Folio::File::Image" => Folio::FilePlacement::Image,
+    "Folio::File::Video" => Folio::FilePlacement::VideoCover,
+    "Folio::File::Audio" => Folio::FilePlacement::AudioCover,
+  }
+
   [
     Folio::File::Document,
     Folio::File::Image,
@@ -59,7 +66,7 @@ class Folio::Console::Api::FileControllerBaseTest < Folio::Console::BaseControll
     test "#{klass} - destroy indestructible" do
       file = create(klass.model_name.singular)
       assert klass.exists?(file.id)
-      file.update_column(:file_placements_count, 1)
+      FILE_PLACEMENT_KLASSES.fetch(klass.to_s).create!(placement: nil, file:)
 
       delete url_for([:console, :api, file, format: :json])
 
@@ -69,6 +76,16 @@ class Folio::Console::Api::FileControllerBaseTest < Folio::Console::BaseControll
       assert_equal 422, response.parsed_body["errors"].first["status"]
       assert_equal "ActiveRecord::RecordNotDestroyed", response.parsed_body["errors"].first["title"]
       assert_equal I18n.t("folio.file.cannot_destroy_file_with_placements"), response.parsed_body["errors"].first["detail"]
+    end
+
+    test "#{klass} - destroy with stale placements counter" do
+      file = create(klass.model_name.singular)
+      file.update_column(:file_placements_count, 1)
+
+      delete url_for([:console, :api, file, format: :json])
+
+      assert_response(:success)
+      assert_not klass.exists?(file.id)
     end
 
     test "#{klass} - show" do

--- a/test/controllers/folio/console/file_placements_controller_test.rb
+++ b/test/controllers/folio/console/file_placements_controller_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Folio::Console::FilePlacementsControllerTest < Folio::Console::BaseControllerTest
+  test "destroy removes an orphaned placement" do
+    video = create(:folio_file_video)
+    placement = Folio::FilePlacement::VideoCover.create!(placement: nil, file: video)
+
+    delete folio.console_file_placement_path(placement)
+
+    assert_redirected_to url_for([:console, video])
+    assert_not Folio::FilePlacement::Base.exists?(placement.id)
+    assert_equal 0, video.reload.file_placements_count
+  end
+
+  test "destroy refuses a placement with a living owner" do
+    video = create(:folio_file_video)
+    page = create(:folio_page, published: true)
+    placement = Folio::FilePlacement::VideoCover.create!(placement: page, file: video)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      delete folio.console_file_placement_path(placement)
+    end
+
+    assert Folio::FilePlacement::Base.exists?(placement.id)
+  end
+end

--- a/test/models/folio/file_test.rb
+++ b/test/models/folio/file_test.rb
@@ -482,6 +482,30 @@ class Folio::FileTest < ActiveSupport::TestCase
     page.update!(published: true)
     assert video.reload.used_in_published_content?
   end
+
+  test "destroy succeeds with stale nonzero counter and no real placements" do
+    video = create(:folio_file_video)
+    video.update_column(:file_placements_count, 3) # simulate counter drift
+
+    assert video.destroy
+    assert_not Folio::File.exists?(video.id)
+  end
+
+  test "destroy aborts with a real placement even when counter says zero" do
+    video = create(:folio_file_video)
+    Folio::FilePlacement::VideoCover.create!(placement: nil, file: video)
+    video.update_column(:file_placements_count, 0)
+
+    assert_not video.reload.destroy
+    assert Folio::File.exists?(video.id)
+  end
+
+  test "live_indestructible_reason reflects real placements, not the counter" do
+    video = create(:folio_file_video)
+    video.update_column(:file_placements_count, 3)
+    assert video.indestructible_reason.present?      # counter-based (lists)
+    assert_nil video.live_indestructible_reason       # live (detail/destroy)
+  end
 end
 
 class Folio::FileUrlOrPathTest < ActiveSupport::TestCase

--- a/test/models/folio/file_test.rb
+++ b/test/models/folio/file_test.rb
@@ -455,6 +455,14 @@ class Folio::FileTest < ActiveSupport::TestCase
     assert video.reload.used_in_published_content?
   end
 
+  test "used_in_published_content? respects future published_at" do
+    video = create(:folio_file_video)
+    page = create(:folio_page, published: true, published_at: 1.day.from_now)
+    Folio::FilePlacement::VideoCover.create!(placement: page, file: video)
+
+    assert_not video.reload.used_in_published_content?
+  end
+
   test "used_in_published_content? counts owners without published? as published" do
     video = create(:folio_file_video)
     site = get_current_or_existing_site_or_create_from_factory

--- a/test/models/folio/file_test.rb
+++ b/test/models/folio/file_test.rb
@@ -433,6 +433,47 @@ class Folio::FileTest < ActiveSupport::TestCase
     assert slug_idx, "Expected an index on folio_files.slug"
     assert slug_idx.unique, "Expected slug index to be unique"
   end
+
+  test "used_in_published_content? is false with no placements" do
+    video = create(:folio_file_video)
+    assert_not video.used_in_published_content?
+  end
+
+  test "used_in_published_content? ignores orphaned placements" do
+    video = create(:folio_file_video)
+    Folio::FilePlacement::VideoCover.create!(placement: nil, file: video)
+    assert_not video.used_in_published_content?
+  end
+
+  test "used_in_published_content? respects owner published?" do
+    video = create(:folio_file_video)
+    page = create(:folio_page, published: false)
+    Folio::FilePlacement::VideoCover.create!(placement: page, file: video)
+    assert_not video.reload.used_in_published_content?
+
+    page.update!(published: true)
+    assert video.reload.used_in_published_content?
+  end
+
+  test "used_in_published_content? counts owners without published? as published" do
+    video = create(:folio_file_video)
+    site = get_current_or_existing_site_or_create_from_factory
+    Folio::FilePlacement::VideoCover.create!(placement: site, file: video)
+    assert video.reload.used_in_published_content?
+  end
+
+  test "used_in_published_content? unwraps atoms to their placement" do
+    video = create(:folio_file_video)
+    page = create(:folio_page, published: false)
+    atom = Dummy::Atom::Contents::Text.new(placement: page, content: "<p>t</p>")
+    atom.save!(validate: false)
+    Folio::FilePlacement::VideoCover.create!(placement: atom, file: video)
+
+    assert_not video.reload.used_in_published_content?
+
+    page.update!(published: true)
+    assert video.reload.used_in_published_content?
+  end
 end
 
 class Folio::FileUrlOrPathTest < ActiveSupport::TestCase

--- a/test/models/folio/file_test.rb
+++ b/test/models/folio/file_test.rb
@@ -506,6 +506,16 @@ class Folio::FileTest < ActiveSupport::TestCase
     assert video.indestructible_reason.present?      # counter-based (lists)
     assert_nil video.live_indestructible_reason       # live (detail/destroy)
   end
+
+  test "destroy removes friendly_id slugs" do
+    video = create(:folio_file_video)
+    slug = video.slug
+    assert FriendlyId::Slug.where(sluggable_type: "Folio::File", sluggable_id: video.id).exists?
+
+    video.destroy!
+    assert_not FriendlyId::Slug.where(sluggable_type: "Folio::File", sluggable_id: video.id).exists?
+    assert_not FriendlyId::Slug.where(slug: slug, sluggable_type: "Folio::File").exists?
+  end
 end
 
 class Folio::FileUrlOrPathTest < ActiveSupport::TestCase

--- a/test/models/folio/file_test.rb
+++ b/test/models/folio/file_test.rb
@@ -516,6 +516,27 @@ class Folio::FileTest < ActiveSupport::TestCase
     assert_not FriendlyId::Slug.where(sluggable_type: "Folio::File", sluggable_id: video.id).exists?
     assert_not FriendlyId::Slug.where(slug: slug, sluggable_type: "Folio::File").exists?
   end
+
+  class CraVideoFile < Folio::File::Video
+    include Folio::CraMediaCloud::FileProcessing
+  end
+
+  test "destroy enqueues CRA media cleanup job for files with remote media" do
+    video = CraVideoFile.new(site: get_any_site)
+    video.file = Folio::Engine.root.join("test/fixtures/folio/blank.mp4")
+    video.dont_run_after_save_jobs = true
+
+    expect_method_called_on(object: video, method: :create_full_media) do
+      video.save!
+    end
+
+    video.update!(remote_services_data: { "remote_id" => "JOB123", "reference_id" => "REF456" })
+
+    assert_enqueued_with(job: Folio::CraMediaCloud::DeleteMediaJob,
+                         args: ["JOB123", { reference_id: "REF456" }]) do
+      video.destroy!
+    end
+  end
 end
 
 class Folio::FileUrlOrPathTest < ActiveSupport::TestCase


### PR DESCRIPTION
## What

- **`Folio::File#used_in_published_content?`** — live check whether a file is used in at least one published piece of content. Unwraps atoms to their parent record, respects the owner's `published?` (incl. `published_at`), ignores orphaned placements, counts owners without a publish concept as published. Early-exit batched iteration; single-record use only (collections need an SQL scope). Intended for host apps that derive public visibility of standalone file pages (e.g. video detail) from usage.
- **Reliable deletion** — a stale `file_placements_count` no longer blocks file destroy. New `Folio::File#live_indestructible_reason` re-verifies the placements message with a live query; used by the model destroy guard, the console file detail and the API destroy. File lists keep the cheap counter. Host-app `indestructible_reason` overrides keep working (non-placements reasons pass through).
- **Console usage list** — orphaned placements (owner deleted) are now rendered with the option to remove them (new orphan-only destroy endpoint, authorized via the file, fail-closed) instead of being silently skipped while blocking deletion. Each row shows a published/unpublished badge of the owning record. The usage section auto-expands when deletion is blocked.
- **Rake tasks** — `folio:files:recalculate_placement_counts` (counter drift fix, `DRY_RUN`/`ALL_VIDEOS`) and `folio:files:report_videos_without_published_usage` (CSV report).
- **Tests** pin the existing FriendlyId slug history cleanup (`dependent: :destroy` from friendly_id) and CRA media cleanup job enqueue on destroy — no behavior change there.

## Notes

- `calculate_published_usage_count` / `published_usage_count` semantics are intentionally unchanged (consumed by usage-limit licensing) — the new visibility check is a separate, documented measure.

## Tests

Model, controller (console + API) and component tests included; suites green.