### PR TITLE
Fix console file search for hostname-like filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **Console file search by filename**: `Folio::File.by_query` now matches a raw `file_name` substring in addition to full-text search. Filenames that look like hostnames (e.g. `name.com_123456.mp4`) are stored by PostgreSQL full-text search as a single `host` lexeme, while pg_search splits the query on dots and ANDs the resulting terms — so searching the whole filename never matched. Searching by filename in the console file/video list now finds the file.
 - **Uppy drag-and-drop**: Only the first active uploader handles window-level file drops, preventing duplicate uploads when a page renders multiple `Folio::UppyComponent` instances.
 
 ## [7.7.1] - 2026-06-16

--- a/app/models/folio/file.rb
+++ b/app/models/folio/file.rb
@@ -137,8 +137,14 @@ class Folio::File < Folio::ApplicationRecord
     return none if query.blank?
 
     sanitized = sanitize_filename_for_search(query)
+    like = "%#{sanitize_sql_like(query.to_s)}%"
+
+    # tsearch splits dotted filenames (e.g. "name.com_123.mp4") into ANDed terms
+    # that never match the single `host` lexeme stored in the tsvector, so a raw
+    # file_name substring match is needed as a fallback.
     where(id: by_query_raw(sanitized).reselect("folio_files.id"))
-      .or(where("folio_files.slug ILIKE ?", "%#{sanitize_sql_like(query.to_s)}%"))
+      .or(where("folio_files.file_name ILIKE ?", like))
+      .or(where("folio_files.slug ILIKE ?", like))
       .or(where(id: tagged_with(query, wild: true, any: true).reselect("folio_files.id")))
   end
 

--- a/test/models/folio/file_by_query_test.rb
+++ b/test/models/folio/file_by_query_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Folio::FileByQueryTest < ActiveSupport::TestCase
+  # Filenames coming from external tools often look like hostnames
+  # (e.g. "ssstwitter.com_1781448018455.mp4"). PostgreSQL full-text search
+  # stores "ssstwitter.com" as a single `host` lexeme, while pg_search splits
+  # the query on dots and ANDs the terms, so "com" never matches and the whole
+  # filename search returns nothing. by_query must still find such files.
+  def video_with_file_name(file_name)
+    video = create(:folio_file_video)
+    video.update!(file_name:)
+    video.reload
+  end
+
+  test "by_query finds a file by its full dotted filename" do
+    video = video_with_file_name("ssstwitter.com_1781448018455.mp4")
+
+    assert_includes Folio::File::Video.by_query("ssstwitter.com_1781448018455.mp4").pluck(:id),
+                    video.id
+  end
+
+  test "by_query finds a file by a mid-filename token" do
+    video = video_with_file_name("ssstwitter.com_1781448018455.mp4")
+
+    assert_includes Folio::File::Video.by_query("1781448018455").pluck(:id),
+                    video.id
+  end
+
+  test "by_query still finds a file by a leading filename token" do
+    video = video_with_file_name("ssstwitter.com_1781448018455.mp4")
+
+    assert_includes Folio::File::Video.by_query("ssstwitter").pluck(:id),
+                    video.id
+  end
+
+  test "by_query does not match unrelated files" do
+    video_with_file_name("ssstwitter.com_1781448018455.mp4")
+    other = video_with_file_name("completely-different-name.mp4")
+
+    refute_includes Folio::File::Video.by_query("ssstwitter.com_1781448018455.mp4").pluck(:id),
+                    other.id
+  end
+end


### PR DESCRIPTION
## Problem

`Folio::File.by_query` relied solely on pg_search full-text search. PostgreSQL stores dotted filenames such as `name.com_123456.mp4` as a single `host` lexeme, while pg_search splits the query on dots and ANDs the resulting terms — so the `com` term never matches and searching the whole filename in the console file/video list returns nothing. Searching by a single token or by content (headline/description/tags) works, but searching by the exact filename does not.

## Fix

Add a raw `file_name ILIKE` substring fallback to `by_query` (mirroring the existing `slug ILIKE` match), so files are found by their filename regardless of FTS tokenization.

- `app/models/folio/file.rb` — `by_query` gains the `file_name ILIKE` branch.
- New model test `test/models/folio/file_by_query_test.rb` (full dotted filename, mid-token, leading token, isolation). 13/13 green incl. existing console by_query tests.
- CHANGELOG [Unreleased] → Fixed.