### PR TITLE
FUL-267: Zarovnání Bandcamp embedu na střed

### DIFF
--- a/data/embed/dist/folio-embed-dist.html
+++ b/data/embed/dist/folio-embed-dist.html
@@ -148,6 +148,11 @@
   width: calc(100% - 2px);
 }
 
+.f-embed__container--bandcamp iframe {
+  width: 100%;
+  max-width: 700px;
+}
+
 .f-embed__youtube-iframe {
   max-width: 100%;
   height: auto;
@@ -262,6 +267,12 @@
 
     if (data.html) {
       container.innerHTML = data.html
+
+      // Bandcamp players are pasted as raw <iframe> with width:100%, so margin-auto
+      // centering is a no-op. Tag the container so CSS can cap the width and center it.
+      if (container.querySelector('iframe[src*="bandcamp.com"]')) {
+        container.classList.add('f-embed__container--bandcamp')
+      }
 
       // Extract and execute scripts manually
       const scripts = container.querySelectorAll('script')

--- a/data/embed/source/embed.css
+++ b/data/embed/source/embed.css
@@ -135,6 +135,11 @@
   width: calc(100% - 2px);
 }
 
+.f-embed__container--bandcamp iframe {
+  width: 100%;
+  max-width: 700px;
+}
+
 .f-embed__youtube-iframe {
   max-width: 100%;
   height: auto;

--- a/data/embed/source/embed.js
+++ b/data/embed/source/embed.js
@@ -102,6 +102,12 @@
     if (data.html) {
       container.innerHTML = data.html
 
+      // Bandcamp players are pasted as raw <iframe> with width:100%, so margin-auto
+      // centering is a no-op. Tag the container so CSS can cap the width and center it.
+      if (container.querySelector('iframe[src*="bandcamp.com"]')) {
+        container.classList.add('f-embed__container--bandcamp')
+      }
+
       // Extract and execute scripts manually
       const scripts = container.querySelectorAll('script')
       scripts.forEach(script => {

--- a/docs/embed.md
+++ b/docs/embed.md
@@ -32,6 +32,15 @@ The module supports the following platforms with their respective URL patterns:
 - **Twitter/X**: `https://twitter.com/{id}` or `https://x.com/{id}`
 - **YouTube**: `https://www.youtube.com/watch?v={id}` or `https://youtu.be/{id}`
 
+### Raw HTML embeds
+
+Embeds pasted as raw `<iframe>` HTML (e.g. Bandcamp, Spotify) are rendered as-is via
+the `"html"` field rather than URL pattern matching. Bandcamp players are pasted with
+`width: 100%`, which makes the default margin-auto centering a no-op. The embed renderer
+detects `iframe[src*="bandcamp.com"]` and tags the container with
+`.f-embed__container--bandcamp`, which caps the player width (700px) so it centers within
+the content column instead of stretching full-width and appearing left-aligned.
+
 ## Validation
 
 ### Using the Validation Concern


### PR DESCRIPTION
## FUL-267 — Zarovnání Bandcamp embedu na střed

### Problém
Po vložení Bandcamp embedu do článku se přehrávač zobrazoval zarovnaný **doleva**, na rozdíl od ostatních embedů (YouTube/Twitter/Instagram), které jsou na střed.

Jira: [FUL-267](https://sinfin-digital.atlassian.net/browse/FUL-267)

### Příčina
Bandcamp se do editoru vkládá jako **surové `<iframe>` HTML**, takže se v `embed.js` renderuje větví `data.html` a obchází detekci typu (`types.json` / `url_type` / `switch`). Vložený iframe má v inline stylu `width: 100%`.

Stávající centrovací pravidlo `.f-embed__container--centered iframe { margin: 0 auto !important }` se sice aplikuje, ale na elementu o šířce 100 % nemá co rozdělit → přehrávač se roztáhne přes celý sloupec a jeho obsah (obal alba) sedí u levého okraje, takže to vypadá zarovnaně doleva. Full-width element nelze vizuálně vystředit, dokud se neomezí jeho šířka.

Ostatní embedy se centrují správně, protože jako rozpoznané typy dostávají omezenou šířku (YouTube `560`/`max-width:100%`, Twitter `max-width:550px`, Instagram `540px`).

### Řešení
Rozpoznat Bandcamp i v raw-HTML větvi a zastropovat šířku přehrávače, aby margin-auto centrování reálně zabralo:

- **`data/embed/source/embed.js`** — ve větvi `data.html` se detekuje `iframe[src*="bandcamp.com"]` a kontejneru se přidá třída `f-embed__container--bandcamp`.
- **`data/embed/source/embed.css`** — nové pravidlo `.f-embed__container--bandcamp iframe { width: 100%; max-width: 700px }`.
- **`data/embed/dist/folio-embed-dist.html`** — regenerováno přes `data/embed/bin/create-static-embed-html` (tento artefakt reálně servíruje `/folio/embed`).
- **`docs/embed.md`** — doplněna sekce „Raw HTML embeds".

Změna se dotýká pouze Bandcamp embedů; ostatní typy jsou beze změny.

### Testování
- [x] Dist regenerován, ověřeno že obsahuje CSS pravidlo i JS detekci.
- [ ] **QA:** vložit Bandcamp iframe do testovacího článku a vizuálně potvrdit vystředění (light/dark, mobil/desktop).

### Poznámky
- `max-width: 700px` je rozumný default pro horizontální Bandcamp přehrávač v textovém sloupci — lze doladit dle skutečné šířky obsahu.


[FUL-267]: https://sinfin-digital.atlassian.net/browse/FUL-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ