### PR TITLE
fix(console): resolve numeric :id by primary key, not a colliding slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **Console record lookup vs numeric slugs**: The console now resolves a numeric `:id` param by primary key first, falling back to FriendlyId only for genuine (non-numeric) slugs. Previously a record whose slug happened to equal another record's id (e.g. a file uploaded as `349444.jpg` gets slug `349444`, colliding with id `349444`) hijacked the lookup, so opening/selecting/editing that id returned the wrong record. `Folio::File` slugs are now also prevented from being purely numeric, so the slug and id namespaces never overlap.
 - **Tiptap toolbar groups**: Only render custom node group dropdowns in the toolbar when the configured `node_groups` entry has `toolbar_slot`, so nodes with only `group` remain slash-menu grouped without appearing in the toolbar.
 - **Console file search by filename**: `Folio::File.by_query` now matches a raw `file_name` substring in addition to full-text search. Filenames that look like hostnames (e.g. `name.com_123456.mp4`) are stored by PostgreSQL full-text search as a single `host` lexeme, while pg_search splits the query on dots and ANDs the resulting terms — so searching the whole filename never matched. Searching by filename in the console file/video list now finds the file.
 - **Ordered multi-select**: Remote autocomplete now shows localized minimum-input guidance for short non-blank queries instead of a normal no-results state.

--- a/app/controllers/folio/console/base_controller.rb
+++ b/app/controllers/folio/console/base_controller.rb
@@ -525,10 +525,22 @@ class Folio::Console::BaseController < Folio::ApplicationController
       name = folio_console_record_variable_name(plural: false)
       return if instance_variable_get(name).present?
 
-      if @klass.respond_to?(:friendly)
-        instance_variable_set(name, @klass.by_site(allowed_record_sites).friendly.find(params[:id]))
+      instance_variable_set(name, find_console_resource(@klass.by_site(allowed_record_sites), params[:id]))
+    end
+
+    # The console addresses records by the :id param. For FriendlyId models a
+    # numeric param is the primary key, but FriendlyId would resolve it against
+    # the slug column first — so a record whose slug happens to equal another
+    # record's id (e.g. a file uploaded as "349444.jpg" gets slug "349444",
+    # colliding with id 349444) would hijack the lookup. Prefer the primary key
+    # for numeric params; fall back to FriendlyId for genuine (non-numeric) slugs.
+    def find_console_resource(scope, id)
+      return scope.find(id) unless scope.respond_to?(:friendly)
+
+      if id.to_s.match?(/\A\d+\z/)
+        scope.find_by(id:) || scope.friendly.find(id)
       else
-        instance_variable_set(name, @klass.by_site(allowed_record_sites).find(params[:id]))
+        scope.friendly.find(id)
       end
     end
 

--- a/app/models/folio/file.rb
+++ b/app/models/folio/file.rb
@@ -456,6 +456,16 @@ class Folio::File < Folio::ApplicationRecord
     update_columns(updates) if updates.any?
   end
 
+  # A purely numeric slug (e.g. derived from a file named "349444.jpg") would be
+  # resolved by FriendlyId ahead of the file whose primary key equals that number
+  # — friendly.find("349444") would return the slug owner instead of id 349444.
+  # Force a neutral, non-numeric slug so the slug and id namespaces never overlap.
+  # NOTE: must stay public — FriendlyId::Candidates calls it on the record.
+  def normalize_friendly_id(value)
+    normalized = super
+    normalized.to_s.match?(/\A\d+\z/) ? neutral_slug : normalized
+  end
+
   private
     def file_presigned_url(expires_in: 1.hour.to_i)
       s3_object_key = [dragonfly_s3_root_path, file_uid].compact_blank.join("/")

--- a/test/controllers/folio/console/api/file_controller_base_test.rb
+++ b/test/controllers/folio/console/api/file_controller_base_test.rb
@@ -409,6 +409,22 @@ class Folio::Console::Api::FileControllerBaseTest < Folio::Console::BaseControll
       assert_equal(file.id, response.parsed_body["data"]["id"].to_i)
     end
 
+    test "#{klass} - file_picker_file_hash resolves numeric :id by primary key, not a colliding numeric slug" do
+      target = create(klass.model_name.singular)
+      decoy = create(klass.model_name.singular)
+      # Legacy file whose (file-name derived) slug equals another file's id,
+      # e.g. a file uploaded as "349444.jpg" -> slug "349444" colliding with id 349444.
+      decoy.update_column(:slug, target.id.to_s)
+
+      # The console JS sends the file's numeric id (not its slug) in :id.
+      slug_url = url_for([:file_picker_file_hash, :console, :api, target, format: :json])
+      get slug_url.sub("/#{target.to_param}/", "/#{target.id}/")
+
+      assert_response(:success)
+      assert_equal(target.id, response.parsed_body["data"]["id"].to_i,
+                   "numeric :id must resolve by primary key, not by decoy ##{decoy.id}'s colliding numeric slug")
+    end
+
     if klass.human_type == "image"
       test "#{klass} - update_thumbnails_crop" do
         file = create(klass.model_name.singular)

--- a/test/models/folio/file_test.rb
+++ b/test/models/folio/file_test.rb
@@ -57,6 +57,14 @@ class Folio::FileTest < ActiveSupport::TestCase
     assert_not image.destroy
   end
 
+  test "generated slug is never purely numeric (would collide with a file id via friendly.find)" do
+    # e.g. a file uploaded as "349444.jpg" must not get slug "349444", which
+    # FriendlyId would then resolve ahead of the file whose id is 349444.
+    file = create(:folio_file_image, headline: "349444")
+    assert_no_match(/\A\d+\z/, file.slug,
+                    "purely numeric slug collides with another file's primary key")
+  end
+
   test "by_query searches by slug" do
     other = create(:folio_file_image, slug: "some-other-file")
     target = create(:folio_file_image, slug: "unique-search-slug")


### PR DESCRIPTION
## Problem

The console loads records via FriendlyId (`@klass.friendly.find(params[:id])`), which matches a numeric `:id` against the **slug** column before the primary key. A record whose slug equals another record's id hijacks the lookup.

This bites files: a file uploaded as `349444.jpg` gets slug `349444`. Once the `folio_files` id sequence reaches `349444`, `friendly.find("349444")` returns the slug owner instead of the file at id `349444` — so opening / selecting (file picker) / editing that id shows the **wrong** file. It grows over time as the id sequence advances into the numeric range historically used as file names, and is invisible in the data (each record is fine; only the lookup is ambiguous).

## Fix

- **`find_console_resource`** (`Folio::Console::BaseController`): for a numeric `:id`, prefer the primary key (`find_by(id:)`), falling back to FriendlyId only for genuine non-numeric slugs. Slug-addressed resources (pages, articles — non-numeric slugs) are unaffected; the numeric branch never triggers for them.
- **`Folio::File#normalize_friendly_id`**: file slugs can no longer be purely numeric (neutral fallback), so the slug and id namespaces never overlap going forward. This also protects the public download/video lookups that resolve files via FriendlyId.

## Tests

- New: `file_picker_file_hash` with a numeric id returns the file at that id even when another file's slug equals it (reproduces the bug; red before, green after).
- New: a generated `Folio::File` slug is never purely numeric.
- Green regression across file controllers, images, pages (slug-addressed), `by_query`, the slug unique-index spec, and shared files.
