### PR TITLE
feat(select): extend ordered multiselect defaults

### DIFF
--- a/app/controllers/folio/console/api/autocompletes_controller.rb
+++ b/app/controllers/folio/console/api/autocompletes_controller.rb
@@ -292,6 +292,7 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
             scope = scope.by_label_query(q)
           else
             scope = scope.all
+            scope = default_apply_param_scope(scope, param_key: :default_scope)
           end
 
           if klass.respond_to?(:filter_by_atom_form_fields)
@@ -350,6 +351,7 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
               scope = scope.by_label_query(q)
             else
               scope = scope.all
+              scope = default_apply_param_scope(scope, param_key: :default_scope)
             end
 
             if klass.respond_to?(:filter_by_atom_form_fields)
@@ -452,8 +454,8 @@ class Folio::Console::Api::AutocompletesController < Folio::Console::Api::BaseCo
       scope
     end
 
-    def default_apply_param_scope(scope)
-      p_scope = params[:scope]
+    def default_apply_param_scope(scope, param_key: :scope)
+      p_scope = params[param_key]
 
       if p_scope.present? && scope.respond_to?(p_scope)
         scope = scope.send(p_scope)

--- a/app/helpers/folio/console/react_helper.rb
+++ b/app/helpers/folio/console/react_helper.rb
@@ -139,6 +139,7 @@ module Folio::Console::ReactHelper
                                 relation_name,
                                 atom_setting: nil,
                                 scope: nil,
+                                default_scope: nil,
                                 order_scope: :ordered,
                                 sortable: true,
                                 required: nil,
@@ -231,6 +232,7 @@ module Folio::Console::ReactHelper
     url = unless options
       react_ordered_multiselect_url(class_names:,
                                     scope:,
+                                    default_scope:,
                                     order_scope:,
                                     label_method:)
     end
@@ -360,11 +362,13 @@ module Folio::Console::ReactHelper
 
     def react_ordered_multiselect_url(class_names:,
                                       scope:,
+                                      default_scope:,
                                       order_scope:,
                                       label_method:)
       options = {
         class_names:,
         scope:,
+        default_scope:,
         order_scope:,
         only_path: true,
       }

--- a/app/helpers/folio/console/react_helper.rb
+++ b/app/helpers/folio/console/react_helper.rb
@@ -165,8 +165,6 @@ module Folio::Console::ReactHelper
     foreign_key = nil
 
     if virtual
-      raise ArgumentError, "Cannot combine virtual ordered multiselect with collection" if collection
-
       class_names = virtual.fetch(:class_name)
       data_serialization = "array"
       data_input_name = virtual.fetch(:input_name)
@@ -182,6 +180,13 @@ module Folio::Console::ReactHelper
           _destroy: false,
         }
       end
+
+      options = react_ordered_multiselect_options(collection,
+                                                  group_method:,
+                                                  group_label_method:,
+                                                  label_method:,
+                                                  value_method:,
+                                                  through_klass: nil) if collection
     else
       klass = f.object.class
       reflection = klass.reflections[relation_name.to_s]

--- a/app/helpers/folio/console/react_helper.rb
+++ b/app/helpers/folio/console/react_helper.rb
@@ -149,6 +149,7 @@ module Folio::Console::ReactHelper
                                 group_label_method: nil,
                                 label_method: :to_console_label,
                                 value_method: :id,
+                                selected_through_records: nil,
                                 virtual: nil)
     class_name = "folio-react-wrap folio-react-wrap--ordered-multiselect"
 
@@ -201,7 +202,7 @@ module Folio::Console::ReactHelper
       foreign_key = reflection.foreign_key
       class_names = through_klass.to_s
 
-      f.object.send(through).each do |record|
+      (selected_through_records || f.object.send(through)).each do |record|
         through_record = through_klass.find(record.send(reflection.foreign_key))
         hash = {
           id: record.id,

--- a/test/controllers/folio/console/api/autocompletes_controller_test.rb
+++ b/test/controllers/folio/console/api/autocompletes_controller_test.rb
@@ -121,6 +121,32 @@ class Folio::Console::Api::AutocompletesControllerTest < Folio::Console::BaseCon
     end
   end
 
+  test "react_select applies default scope only for blank query" do
+    default_page = create(:folio_page, title: "Default page")
+    searchable_page = create(:folio_page, title: "Searchable page")
+
+    Folio::Page.define_singleton_method(:folio_test_default_options) do
+      where(id: default_page.id)
+    end
+
+    begin
+      get react_select_console_api_autocomplete_path(class_names: "Folio::Page",
+                                                     default_scope: "folio_test_default_options")
+      json = JSON.parse(response.body)
+
+      assert_equal [default_page.id], json["data"].map { |item| item["id"] }
+
+      get react_select_console_api_autocomplete_path(class_names: "Folio::Page",
+                                                     default_scope: "folio_test_default_options",
+                                                     q: "Searchable")
+      json = JSON.parse(response.body)
+
+      assert_equal [searchable_page.id], json["data"].map { |item| item["id"] }
+    ensure
+      Folio::Page.singleton_class.remove_method(:folio_test_default_options)
+    end
+  end
+
   test "show pagination" do
     # Create 30 pages matching query to test pagination
     30.times { |i| create(:folio_page, title: "Foo page #{i + 1}") }

--- a/test/helpers/folio/console/react_helper_test.rb
+++ b/test/helpers/folio/console/react_helper_test.rb
@@ -171,6 +171,63 @@ class Folio::Console::ReactHelperTest < ActionView::TestCase
     assert_equal first_author.id, items[0]["value"]
   end
 
+  test "react_ordered_multiselect uses explicit selected through records for items" do
+    article = create(:dummy_blog_article)
+    first_author = create(:dummy_blog_author,
+                          site: article.site,
+                          locale: article.locale,
+                          first_name: "Ada",
+                          last_name: "Lovelace")
+    second_author = create(:dummy_blog_author,
+                           site: article.site,
+                           locale: article.locale,
+                           first_name: "Grace",
+                           last_name: "Hopper")
+    article.authors << first_author
+    article.authors << second_author
+
+    first_link = article.author_article_links.find_by!(author: first_author)
+
+    wrap = ordered_multiselect_wrap(article,
+                                    selected_through_records: [first_link])
+    items = data_json(wrap, "items")
+
+    assert_equal "#{article.model_name.param_key}[author_article_links_attributes]",
+                 wrap["data-param-base"]
+    assert_equal "dummy_blog_author_id", wrap["data-foreign-key"]
+    assert_equal [first_author.id], items.map { |item| item["value"] }
+    assert_equal ["Ada Lovelace"], items.map { |item| item["label"] }
+  end
+
+  test "react_ordered_multiselect keeps selected through records marked for destruction as removed items" do
+    article = create(:dummy_blog_article)
+    kept_author = create(:dummy_blog_author,
+                         site: article.site,
+                         locale: article.locale,
+                         first_name: "Ada",
+                         last_name: "Lovelace")
+    removed_author = create(:dummy_blog_author,
+                            site: article.site,
+                            locale: article.locale,
+                            first_name: "Grace",
+                            last_name: "Hopper")
+    article.authors << kept_author
+    article.authors << removed_author
+
+    kept_link = article.author_article_links.find_by!(author: kept_author)
+    removed_link = article.author_article_links.find_by!(author: removed_author)
+    removed_link.mark_for_destruction
+
+    wrap = ordered_multiselect_wrap(article,
+                                    selected_through_records: [kept_link, removed_link])
+    items = data_json(wrap, "items")
+    removed_items = data_json(wrap, "removed-items")
+
+    assert_equal [kept_author.id], items.map { |item| item["value"] }
+    assert_equal [removed_link.id], removed_items.map { |item| item["id"] }
+    assert_equal [removed_author.id], removed_items.map { |item| item["value"] }
+  end
+
   test "react_ordered_multiselect keeps selected items with local options" do
     article = create(:dummy_blog_article)
     author = create(:dummy_blog_author,

--- a/test/helpers/folio/console/react_helper_test.rb
+++ b/test/helpers/folio/console/react_helper_test.rb
@@ -133,6 +133,44 @@ class Folio::Console::ReactHelperTest < ActionView::TestCase
     assert_equal second_author.id, options[1]["options"][0]["id"]
   end
 
+  test "react_ordered_multiselect renders virtual grouped local collection options" do
+    first_author = create(:dummy_blog_author,
+                          first_name: "Ada",
+                          last_name: "Lovelace")
+    second_author = create(:dummy_blog_author,
+                           first_name: "Grace",
+                           last_name: "Hopper")
+    collection = [
+      Group.new("First group", [first_author]),
+      Group.new("Second group", [second_author]),
+    ]
+
+    wrap = ordered_multiselect_wrap(build(:dummy_blog_article),
+                                    relation_name: :issue_ids,
+                                    virtual: {
+                                      class_name: "Dummy::Blog::Author",
+                                      selected: [first_author],
+                                      input_name: "dummy_blog_article[issue_ids][]",
+                                    },
+                                    label_method: :full_name,
+                                    collection:,
+                                    group_method: :records,
+                                    group_label_method: :label)
+    options = data_json(wrap, "options")
+    items = data_json(wrap, "items")
+
+    assert_nil wrap["data-url"]
+    assert_equal "array", wrap["data-serialization"]
+    assert_equal "dummy_blog_article[issue_ids][]", wrap["data-input-name"]
+    assert_equal "First group", options[0]["label"]
+    assert_equal first_author.id, options[0]["options"][0]["id"]
+    assert_equal "Ada Lovelace", options[0]["options"][0]["label"]
+    assert_equal "Dummy::Blog::Author", options[0]["options"][0]["type"]
+    assert_equal "Second group", options[1]["label"]
+    assert_equal second_author.id, options[1]["options"][0]["id"]
+    assert_equal first_author.id, items[0]["value"]
+  end
+
   test "react_ordered_multiselect keeps selected items with local options" do
     article = create(:dummy_blog_article)
     author = create(:dummy_blog_author,

--- a/test/helpers/folio/console/react_helper_test.rb
+++ b/test/helpers/folio/console/react_helper_test.rb
@@ -17,6 +17,14 @@ class Folio::Console::ReactHelperTest < ActionView::TestCase
     assert_nil wrap["data-input-name"]
   end
 
+  test "react_ordered_multiselect passes default scope to remote autocomplete" do
+    wrap = ordered_multiselect_wrap(build(:dummy_blog_article),
+                                    default_scope: :featured)
+    params = Rack::Utils.parse_nested_query(URI.parse(wrap["data-url"]).query)
+
+    assert_equal "featured", params["default_scope"]
+  end
+
   test "react_ordered_multiselect renders virtual remote array data" do
     author = create(:dummy_blog_author,
                     first_name: "Ada",


### PR DESCRIPTION
 ## Summary

  - allow virtual ordered multiselects to use a local `collection`, including grouped options
  - add `selected_through_records` to `react_ordered_multiselect` so callers can explicitly control which through/link records are rendered as selected items
  - add `default_scope` support for ordered multiselect autocomplete defaults, applied only before the user starts searching

  ## Details

The ordered multiselect keeps the existing JS/data contract unchanged. Existing calls without the new options behave the same as before.