### PR TITLE
 Fix locale-aware Folio current cache key timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file.
 - default `devise_modules` moved to folio config, so each app can set their own set. Default are `%i[database_authenticatable recoverable rememberable trackable invitable timeoutable lockable]
 - added option `Rails.application.config.folio_cookie_consent_configuration[:keep_attached_after_accept]` (default false). Set it `true` if app allways display link to open cookies settings.
 
+### Fixed
+
+- set `Folio::Current.cache_key_base` only after request locale resolution and use a locale-independent cache key for current site lookup
+
 ## [6.5.1] - 2025-06-18
 
 ### Added

--- a/app/controllers/concerns/folio/application_controller_base.rb
+++ b/app/controllers/concerns/folio/application_controller_base.rb
@@ -16,6 +16,7 @@ module Folio::ApplicationControllerBase
     layout :current_site_based_layout
 
     before_action :set_i18n_locale
+    before_action :set_folio_current_cache_key_base
 
     before_action :set_cookies_for_log
 
@@ -34,6 +35,10 @@ module Folio::ApplicationControllerBase
     else
       I18n.locale = Folio::Current.site.locale
     end
+  end
+
+  def set_folio_current_cache_key_base
+    Folio::Current.cache_key_base = Rails.application.config.action_controller.perform_caching ? try(:cache_key_base) : nil
   end
 
   def default_url_options

--- a/app/controllers/concerns/folio/set_current_request_details.rb
+++ b/app/controllers/concerns/folio/set_current_request_details.rb
@@ -20,7 +20,18 @@ module Folio::SetCurrentRequestDetails
         Folio::Current.setup!(request:,
                               user: current_user,
                               session:,
-                              cache_key_base: Rails.application.config.action_controller.perform_caching ? try(:cache_key_base) : nil)
+                              site_cache_key_base: Rails.application.config.action_controller.perform_caching ? folio_current_site_cache_key_base : nil)
+      end
+    end
+
+    def folio_current_site_cache_key_base
+      @folio_current_site_cache_key_base ||= Rails.cache.fetch(["Folio::Current.site_cache_key_base", request.host], expires_in: 30.seconds) do
+        [
+          ENV["CURRENT_RELEASE_COMMIT_HASH"],
+          request.host,
+          Folio::Site.maximum(:updated_at)&.to_f,
+          Folio::Site.count,
+        ]
       end
     end
 end

--- a/app/models/folio/current.rb
+++ b/app/models/folio/current.rb
@@ -14,6 +14,7 @@ class Folio::Current < ActiveSupport::CurrentAttributes
             :session,
             :ability,
             :cache_key_base,
+            :site_cache_key_base,
             :skip_caching
 
   SITE_KEYS = %i[
@@ -27,11 +28,11 @@ class Folio::Current < ActiveSupport::CurrentAttributes
     attributes
   end
 
-  def setup!(request:, user: nil, session: nil, cache_key_base: nil)
-    setup_folio_data(request:, user:, session:, cache_key_base:)
+  def setup!(request:, user: nil, session: nil, cache_key_base: nil, site_cache_key_base: cache_key_base)
+    setup_folio_data(request:, user:, session:, cache_key_base:, site_cache_key_base:)
   end
 
-  def setup_folio_data(request:, user:, session:, cache_key_base:)
+  def setup_folio_data(request:, user:, session:, cache_key_base:, site_cache_key_base:)
     self.host = request.host
     self.request_id = request.uuid
     self.user_agent = request.user_agent
@@ -41,8 +42,9 @@ class Folio::Current < ActiveSupport::CurrentAttributes
     self.session = session
 
     self.cache_key_base = cache_key_base
+    self.site_cache_key_base = site_cache_key_base
 
-    # keep the code that uses site under cache_key_base
+    # keep the code that uses site under site_cache_key_base
     nillify_site_records unless self.class.site_matches_host?(site:, host:)
     self.ability = Folio::Ability.new(user, site)
   end
@@ -68,9 +70,9 @@ class Folio::Current < ActiveSupport::CurrentAttributes
   end
 
   def self.cache_aware_get_site(host: nil)
-    if !skip_caching && cache_key_base
-      # cache_key_base should contain request.host
-      Rails.cache.fetch(["Folio::Current.cache_aware_get_site"] + cache_key_base, expires_in: Folio.expires_in) do
+    if !skip_caching && site_cache_key_base
+      # site_cache_key_base should contain request.host
+      Rails.cache.fetch(["Folio::Current.cache_aware_get_site"] + site_cache_key_base, expires_in: Folio.expires_in) do
         get_site(host:)
       end
     else
@@ -101,8 +103,8 @@ class Folio::Current < ActiveSupport::CurrentAttributes
   end
 
   def self.cache_aware_get_main_site
-    if !skip_caching && cache_key_base
-      Rails.cache.fetch(["Folio::Current.cache_aware_get_main_site"] + cache_key_base, expires_in: Folio.expires_in) do
+    if !skip_caching && site_cache_key_base
+      Rails.cache.fetch(["Folio::Current.cache_aware_get_main_site"] + site_cache_key_base, expires_in: Folio.expires_in) do
         get_main_site
       end
     else


### PR DESCRIPTION
 Oprava problému, kdy se Folio::Current.cache_key_base mohl vyhodnotit ještě před nastavením I18n.locale. To mohlo způsobit použití cache klíče pro špatný jazyk a následné vyrenderování lokalizovaného obsahu z cache v
  jiné locale.

  Změny

  - oddělen locale-independent cache key pro lookup Folio::Current.site
  - Folio::Current.cache_key_base se nastavuje až po set_i18n_locale
  - doplněn regresní test
  - doplněn changelog záznam

  Ověření

  - bin/rails test test/controllers/folio/application_controller_base_test.rb
  - relevantní integrační testy pro user flow prošly úspěšně
