### PR TITLE
fix(embed): responsive raw-HTML/YouTube iframes + opt-in full width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - **`Folio::Site.additional_strong_params`**: the full list of params permitted in the site console form (`site_params`), defaulting to `additional_params`. Override it (e.g. `super + %i[…]`) to permit fields you render yourself — e.g. in a custom `console_form_tabs` tab — without them being auto-rendered in the settings tab.
 - **Embed lazy loading**: `Folio::Embed::BoxComponent` accepts `lazy: false` to load immediately instead of waiting for intersection; the default remains `lazy: true`.
 - **Console icons**: Add the `lock_open_variant` icon.
+- **Embed full-width iframes**: `Folio::Embed::BoxComponent` accepts `full_width_iframes: true` to let embedded iframes grow to the container width instead of stopping at their `width` attribute (560px for a URL-embedded YouTube video, 360px for Shorts). The default is `false`, so host apps opt in per site or per placement. The same option is accepted by `input as: :embed` and by `:embed` tiptap node attributes (where it may be a Proc resolved at render time) so console previews match the frontend.
 
 ### Changed
 
@@ -29,8 +30,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- **Embed HTML rendering**: Iframes pasted as raw HTML (e.g. a copied YouTube `<iframe>` embed code) now scale responsively using the aspect ratio derived from their `width`/`height` attributes, instead of keeping a fixed pixel size that overflowed and got clipped in narrower containers.
-- **Embed YouTube rendering**: YouTube iframes embedded by URL now fill the container width instead of staying at their literal `width` attribute, so they scale up in containers wider than 560px (360px for Shorts) rather than only shrinking in narrower ones.
+- **Embed HTML rendering**: Iframes pasted as raw HTML (e.g. a copied YouTube `<iframe>` embed code) now scale down using the aspect ratio derived from their `width`/`height` attributes, instead of keeping a fixed pixel size that overflowed and got clipped in narrower containers. They still stop at their attribute width in wider containers unless `full_width_iframes: true` is passed.
 - **Embed inputs**: Server validation messages now appear directly beneath the HTML/URL field, before the preview, rather than above its label.
 - **Media-source usage constraints**: Usage counts include files placed through atoms, media-source rules are authoritative in the file console, and site-specific limits remain attached to the media source instead of being copied to files.
 - **Media source site rules**: Persisted rules can now be removed and re-added for the same site in one edit without tripping uniqueness validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - **Embed HTML rendering**: Iframes pasted as raw HTML (e.g. a copied YouTube `<iframe>` embed code) now scale responsively using the aspect ratio derived from their `width`/`height` attributes, instead of keeping a fixed pixel size that overflowed and got clipped in narrower containers.
+- **Embed YouTube rendering**: YouTube iframes embedded by URL now fill the container width instead of staying at their literal `width` attribute, so they scale up in containers wider than 560px (360px for Shorts) rather than only shrinking in narrower ones.
 - **Embed inputs**: Server validation messages now appear directly beneath the HTML/URL field, before the preview, rather than above its label.
 - **Media-source usage constraints**: Usage counts include files placed through atoms, media-source rules are authoritative in the file console, and site-specific limits remain attached to the media source instead of being copied to files.
 - **Media source site rules**: Persisted rules can now be removed and re-added for the same site in one edit without tripping uniqueness validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **Embed HTML rendering**: Iframes pasted as raw HTML (e.g. a copied YouTube `<iframe>` embed code) now scale responsively using the aspect ratio derived from their `width`/`height` attributes, instead of keeping a fixed pixel size that overflowed and got clipped in narrower containers.
 - **Embed inputs**: Server validation messages now appear directly beneath the HTML/URL field, before the preview, rather than above its label.
 - **Media-source usage constraints**: Usage counts include files placed through atoms, media-source rules are authoritative in the file console, and site-specific limits remain attached to the media source instead of being copied to files.
 - **Media source site rules**: Persisted rules can now be removed and re-added for the same site in one edit without tripping uniqueness validation.

--- a/app/components/folio/console/tiptap/overlay/form/input_component.rb
+++ b/app/components/folio/console/tiptap/overlay/form/input_component.rb
@@ -171,7 +171,14 @@ class Folio::Console::Tiptap::Overlay::Form::InputComponent < Folio::Console::Ap
       @f.input @key,
                as: :embed,
                centered: true,
+               full_width_iframes: attr_config_value(:full_width_iframes) == true,
                hint:
+    end
+
+    # Allows attr configs to be resolved at render time, e.g. per current site.
+    def attr_config_value(key)
+      raw = @attr_config[key]
+      raw.is_a?(Proc) ? raw.call(@f.object) : raw
     end
 
     def default_value

--- a/app/components/folio/embed/box_component.js
+++ b/app/components/folio/embed/box_component.js
@@ -24,6 +24,7 @@ window.Folio.Stimulus.register('f-embed-box', class extends window.Stimulus.Cont
     lazy: Boolean,
     folioEmbedData: Object,
     centered: Boolean,
+    fullWidthIframes: Boolean,
     backgroundColor: String,
     lightModeBackgroundColor: String,
     darkModeBackgroundColor: String
@@ -79,6 +80,10 @@ window.Folio.Stimulus.register('f-embed-box', class extends window.Stimulus.Cont
 
     if (this.centeredValue) {
       params.set('centered', '1')
+    }
+
+    if (this.fullWidthIframesValue) {
+      params.set('fullWidthIframes', '1')
     }
 
     if (this.hasDualBackgroundColors) {

--- a/app/components/folio/embed/box_component.rb
+++ b/app/components/folio/embed/box_component.rb
@@ -8,6 +8,7 @@ class Folio::Embed::BoxComponent < ApplicationComponent
                  light_mode_background_color: nil,
                  dark_mode_background_color: nil,
                  class_name: nil,
+                 full_width_iframes: false,
                  lazy: true)
     @folio_embed_data = folio_embed_data.is_a?(Hash) ? folio_embed_data : {}
     @data = data
@@ -16,6 +17,7 @@ class Folio::Embed::BoxComponent < ApplicationComponent
     @light_mode_background_color = light_mode_background_color
     @dark_mode_background_color = dark_mode_background_color
     @class_name = class_name
+    @full_width_iframes = full_width_iframes
     @lazy = lazy
   end
 
@@ -53,6 +55,7 @@ class Folio::Embed::BoxComponent < ApplicationComponent
                                 background_color: @background_color,
                                 light_mode_background_color: @light_mode_background_color,
                                 dark_mode_background_color: @dark_mode_background_color,
+                                full_width_iframes: @full_width_iframes,
                               },
                               action: {
                                 "message@window" => "onWindowMessage",

--- a/app/components/folio/input/embed/inner_component.rb
+++ b/app/components/folio/input/embed/inner_component.rb
@@ -7,11 +7,13 @@ class Folio::Input::Embed::InnerComponent < ApplicationComponent
                  compact: false,
                  centered: false,
                  background_color: nil,
+                 full_width_iframes: false,
                  error: nil)
     @folio_embed_data = folio_embed_data
     @compact = compact
     @centered = centered
     @background_color = background_color
+    @full_width_iframes = full_width_iframes
     @error = error
   end
 

--- a/app/components/folio/input/embed/inner_component.slim
+++ b/app/components/folio/input/embed/inner_component.slim
@@ -15,4 +15,5 @@ div class=bem_class_name data=data
     = render(Folio::Embed::BoxComponent.new(folio_embed_data: @folio_embed_data,
                                             data: stimulus_target("box"),
                                             background_color: @background_color,
+                                            full_width_iframes: @full_width_iframes,
                                             centered: @centered))

--- a/app/inputs/embed_input.rb
+++ b/app/inputs/embed_input.rb
@@ -45,6 +45,7 @@ class EmbedInput < SimpleForm::Inputs::StringInput
       @builder.template.render(Folio::Input::Embed::InnerComponent.new(folio_embed_data:,
                                                                        centered: !!options[:centered],
                                                                        background_color: options[:background_color],
+                                                                       full_width_iframes: !!options[:full_width_iframes],
                                                                        compact: options[:compact],
                                                                        error:))
     end

--- a/data/embed/dist/folio-embed-dist.html
+++ b/data/embed/dist/folio-embed-dist.html
@@ -151,7 +151,6 @@
 }
 
 .f-embed__youtube-iframe {
-  width: 100%;
   max-width: 100%;
   height: auto;
   aspect-ratio: 560 / 315;
@@ -159,6 +158,10 @@
 
 .f-embed__youtube-iframe--shorts {
   aspect-ratio: 360 / 640;
+}
+
+.f-embed__container--full-width-iframes .f-embed__youtube-iframe {
+  width: 100%;
 }
      </style>
     <script type="text/javascript">
@@ -240,16 +243,21 @@
     }
   }
 
-  const makeEmbeddedIframesResponsive = (container) => {
+  // Without fillWidth the iframe keeps its attribute width and only shrinks to
+  // fit narrower containers; fillWidth also lets it grow to the container.
+  const makeEmbeddedIframesResponsive = (container, fillWidth) => {
     container.querySelectorAll('iframe').forEach((iframe) => {
       const width = parseInt(iframe.getAttribute('width'), 10)
       const height = parseInt(iframe.getAttribute('height'), 10)
 
       if (width > 0 && height > 0) {
         iframe.style.aspectRatio = `${width} / ${height}`
-        iframe.style.width = '100%'
         iframe.style.height = 'auto'
         iframe.style.maxWidth = '100%'
+
+        if (fillWidth) {
+          iframe.style.width = '100%'
+        }
       }
     })
   }
@@ -264,9 +272,15 @@
       container.classList.add('f-embed__container--centered')
     }
 
+    const fullWidthIframes = urlParams.get('fullWidthIframes') === '1'
+
+    if (fullWidthIframes) {
+      container.classList.add('f-embed__container--full-width-iframes')
+    }
+
     if (data.html) {
       container.innerHTML = data.html
-      makeEmbeddedIframesResponsive(container)
+      makeEmbeddedIframesResponsive(container, fullWidthIframes)
 
       // Extract and execute scripts manually
       const scripts = container.querySelectorAll('script')

--- a/data/embed/dist/folio-embed-dist.html
+++ b/data/embed/dist/folio-embed-dist.html
@@ -151,6 +151,7 @@
 }
 
 .f-embed__youtube-iframe {
+  width: 100%;
   max-width: 100%;
   height: auto;
   aspect-ratio: 560 / 315;

--- a/data/embed/dist/folio-embed-dist.html
+++ b/data/embed/dist/folio-embed-dist.html
@@ -116,6 +116,7 @@
 
 .f-embed__container iframe {
   display: block;
+  max-width: 100%;
 }
 
 .f-embed__container--centered .instagram-media,
@@ -238,6 +239,20 @@
     }
   }
 
+  const makeEmbeddedIframesResponsive = (container) => {
+    container.querySelectorAll('iframe').forEach((iframe) => {
+      const width = parseInt(iframe.getAttribute('width'), 10)
+      const height = parseInt(iframe.getAttribute('height'), 10)
+
+      if (width > 0 && height > 0) {
+        iframe.style.aspectRatio = `${width} / ${height}`
+        iframe.style.width = '100%'
+        iframe.style.height = 'auto'
+        iframe.style.maxWidth = '100%'
+      }
+    })
+  }
+
   const createEmbedElement = (data) => {
     const container = document.createElement('div')
     container.className = 'f-embed__container'
@@ -250,6 +265,7 @@
 
     if (data.html) {
       container.innerHTML = data.html
+      makeEmbeddedIframesResponsive(container)
 
       // Extract and execute scripts manually
       const scripts = container.querySelectorAll('script')

--- a/data/embed/source/embed.css
+++ b/data/embed/source/embed.css
@@ -138,7 +138,6 @@
 }
 
 .f-embed__youtube-iframe {
-  width: 100%;
   max-width: 100%;
   height: auto;
   aspect-ratio: 560 / 315;
@@ -146,4 +145,8 @@
 
 .f-embed__youtube-iframe--shorts {
   aspect-ratio: 360 / 640;
+}
+
+.f-embed__container--full-width-iframes .f-embed__youtube-iframe {
+  width: 100%;
 }

--- a/data/embed/source/embed.css
+++ b/data/embed/source/embed.css
@@ -138,6 +138,7 @@
 }
 
 .f-embed__youtube-iframe {
+  width: 100%;
   max-width: 100%;
   height: auto;
   aspect-ratio: 560 / 315;

--- a/data/embed/source/embed.css
+++ b/data/embed/source/embed.css
@@ -103,6 +103,7 @@
 
 .f-embed__container iframe {
   display: block;
+  max-width: 100%;
 }
 
 .f-embed__container--centered .instagram-media,

--- a/data/embed/source/embed.js
+++ b/data/embed/source/embed.js
@@ -76,16 +76,21 @@
     }
   }
 
-  const makeEmbeddedIframesResponsive = (container) => {
+  // Without fillWidth the iframe keeps its attribute width and only shrinks to
+  // fit narrower containers; fillWidth also lets it grow to the container.
+  const makeEmbeddedIframesResponsive = (container, fillWidth) => {
     container.querySelectorAll('iframe').forEach((iframe) => {
       const width = parseInt(iframe.getAttribute('width'), 10)
       const height = parseInt(iframe.getAttribute('height'), 10)
 
       if (width > 0 && height > 0) {
         iframe.style.aspectRatio = `${width} / ${height}`
-        iframe.style.width = '100%'
         iframe.style.height = 'auto'
         iframe.style.maxWidth = '100%'
+
+        if (fillWidth) {
+          iframe.style.width = '100%'
+        }
       }
     })
   }
@@ -100,9 +105,15 @@
       container.classList.add('f-embed__container--centered')
     }
 
+    const fullWidthIframes = urlParams.get('fullWidthIframes') === '1'
+
+    if (fullWidthIframes) {
+      container.classList.add('f-embed__container--full-width-iframes')
+    }
+
     if (data.html) {
       container.innerHTML = data.html
-      makeEmbeddedIframesResponsive(container)
+      makeEmbeddedIframesResponsive(container, fullWidthIframes)
 
       // Extract and execute scripts manually
       const scripts = container.querySelectorAll('script')

--- a/data/embed/source/embed.js
+++ b/data/embed/source/embed.js
@@ -76,6 +76,20 @@
     }
   }
 
+  const makeEmbeddedIframesResponsive = (container) => {
+    container.querySelectorAll('iframe').forEach((iframe) => {
+      const width = parseInt(iframe.getAttribute('width'), 10)
+      const height = parseInt(iframe.getAttribute('height'), 10)
+
+      if (width > 0 && height > 0) {
+        iframe.style.aspectRatio = `${width} / ${height}`
+        iframe.style.width = '100%'
+        iframe.style.height = 'auto'
+        iframe.style.maxWidth = '100%'
+      }
+    })
+  }
+
   const createEmbedElement = (data) => {
     const container = document.createElement('div')
     container.className = 'f-embed__container'
@@ -88,6 +102,7 @@
 
     if (data.html) {
       container.innerHTML = data.html
+      makeEmbeddedIframesResponsive(container)
 
       // Extract and execute scripts manually
       const scripts = container.querySelectorAll('script')

--- a/docs/embed.md
+++ b/docs/embed.md
@@ -246,6 +246,25 @@ For displaying embedded content on the frontend, use the `Folio::Embed::BoxCompo
 - Stimulus controller `f-embed-box` for interaction handling
 - Configurable centering and custom data attributes
 
+#### Iframe sizing
+
+Iframes inside the embed always **shrink** to fit a container narrower than themselves: raw-HTML iframes get an `aspect-ratio` derived from their `width`/`height` attributes plus `max-width: 100%`, so they scale down instead of overflowing and being clipped by the embed box.
+
+They do **not** grow past the size given by their attributes — a raw-HTML YouTube snippet stays 560x315 and a URL-embedded YouTube video stays 560px wide (360px for Shorts) in a wider container.
+
+Pass `full_width_iframes: true` to let them fill the container width as well:
+
+```rb
+<%= render(Folio::Embed::BoxComponent.new(
+  folio_embed_data: @post.folio_embed_data,
+  full_width_iframes: true
+)) %>
+```
+
+With the flag on, the component forwards `fullWidthIframes=1` to `/folio/embed`, which adds `f-embed__container--full-width-iframes` to the embed container and applies `width: 100%` to the iframes.
+
+The same option works on the embed input (`f.input :folio_embed_data, as: :embed, full_width_iframes: true`) so console previews match the frontend. Because it is opt-in, apps that render embeds on several sites can enable it per site.
+
 #### Background options
 
 `Folio::Embed::BoxComponent` supports two background modes:

--- a/docs/tiptap.md
+++ b/docs/tiptap.md
@@ -474,6 +474,17 @@ node.folio_embed_data  # => nil
 
 **Supported embed types**: YouTube, Instagram, Pinterest, Twitter/X. The `Folio::Embed` module handles URL detection and validation for supported platforms.
 
+The console overlay preview keeps iframes at their literal `width`/`height` attributes. Pass `full_width_iframes: true` to let them fill the container instead (see [Embed](embed.md#iframe-sizing)). A Proc is resolved at render time, which lets a multi-site app follow the current site:
+
+```rb
+tiptap_node structure: {
+  folio_embed_data: {
+    type: :embed,
+    full_width_iframes: -> (_node) { Folio::Current.site.is_a?(MyApp::Site::Blog) },
+  },
+}
+```
+
 #### Integer Attribute Behavior
 
 Integer attributes (`:integer` or `{ type: :integer }`) provide automatic type conversion and validation:

--- a/test/components/folio/embed/box_component_test.rb
+++ b/test/components/folio/embed/box_component_test.rb
@@ -27,6 +27,22 @@ class Folio::Embed::BoxComponentTest < Folio::ComponentTest
     assert_selector(".f-embed-box")
   end
 
+  def test_render_full_width_iframes_defaults_to_false
+    folio_embed_data = { "active" => true, "url" => "https://www.youtube.com/watch?v=8DPcXHMGMBc", "type" => "youtube" }
+
+    render_inline(Folio::Embed::BoxComponent.new(folio_embed_data:))
+
+    assert_selector(".f-embed-box[data-f-embed-box-full-width-iframes-value='false']")
+  end
+
+  def test_render_full_width_iframes
+    folio_embed_data = { "active" => true, "url" => "https://www.youtube.com/watch?v=8DPcXHMGMBc", "type" => "youtube" }
+
+    render_inline(Folio::Embed::BoxComponent.new(folio_embed_data:, full_width_iframes: true))
+
+    assert_selector(".f-embed-box[data-f-embed-box-full-width-iframes-value='true']")
+  end
+
   def test_render_dual_theme_background_colors
     folio_embed_data = { "active" => false }
 


### PR DESCRIPTION
## Summary
Pulls 3 self-contained embed-responsiveness fixes out of `feat/virtual-ordered-multiselect` (diverged, unmerged) so they can land on `master` independently.

- Raw-HTML iframe embeds (e.g. pasted `<iframe>` snippets) now derive an aspect ratio from `width`/`height` and scale down in narrow containers instead of overflowing.
- URL-embedded YouTube iframes fill their container width.
- New opt-in `full_width_iframes: true` on `Folio::Embed::BoxComponent` (and `input as: :embed` / `:embed` tiptap node attrs) lets host apps allow iframes to grow past their attribute width per site/placement; default stays `false`.

## Test plan
- [ ] `bundle exec rails test` for embed-related specs
- [ ] Manual check: paste a raw HTML iframe embed and a YouTube URL embed, verify scaling at narrow/wide breakpoints