### PR TITLE
fix(devise): match sign-in emails case-insensitively

### DIFF
--- a/app/cells/folio/devise/email_input_cell.rb
+++ b/app/cells/folio/devise/email_input_cell.rb
@@ -3,14 +3,19 @@
 class Folio::Devise::EmailInputCell < Folio::Devise::ApplicationCell
   def input
     model.input :email,
+                as: :email,
                 wrapper: false,
                 label: false,
                 required: true,
                 disabled: options[:disabled],
                 placeholder: options[:placeholder],
                 input_html: {
+                  type: "email",
                   autofocus: options[:autofocus].nil? || options[:autofocus],
                   autocomplete: "email",
+                  autocapitalize: "none",
+                  autocorrect: "off",
+                  spellcheck: "false",
                   value: model.object.email.presence,
                   data: { test_id: options[:test_id].presence },
                   id: input_id, # need ID for generating "<label for",

--- a/app/controllers/concerns/folio/users/devise_controller_base.rb
+++ b/app/controllers/concerns/folio/users/devise_controller_base.rb
@@ -61,7 +61,10 @@ module Folio::Users::DeviseControllerBase
   end
 
   def email_belongs_to_invited_pending_user?(email)
-    user = Folio::User.find_by(email: email.to_s.strip.downcase)
+    auth_site = Folio::Current.enabled_site_for_crossdomain_devise || Folio::Current.site
+    return false unless auth_site
+
+    user = Folio::User.find_for_authentication(email:, auth_site_id: auth_site.id.to_s)
     user && user.invitation_created_at? && user.invitation_accepted_at.nil? && user.sign_in_count == 0
   end
 

--- a/app/controllers/concerns/folio/users/devise_controller_base.rb
+++ b/app/controllers/concerns/folio/users/devise_controller_base.rb
@@ -61,7 +61,7 @@ module Folio::Users::DeviseControllerBase
   end
 
   def email_belongs_to_invited_pending_user?(email)
-    user = Folio::User.find_by(email:)
+    user = Folio::User.find_by(email: email.to_s.strip.downcase)
     user && user.invitation_created_at? && user.invitation_accepted_at.nil? && user.sign_in_count == 0
   end
 

--- a/app/models/folio/user.rb
+++ b/app/models/folio/user.rb
@@ -392,8 +392,8 @@ class Folio::User < Folio::ApplicationRecord
 
   private
     # Override of Devise method to scope authentication by zone.
-    # Apply Devise case_insensitive_keys / strip_whitespace_keys here: this
-    # method replaces the default lookup, so Warden does not run the filter.
+    # Default Devise lookup filters email in find_first_by_auth_conditions;
+    # this override skips that, so apply devise_parameter_filter here.
     def self.find_for_authentication(warden_params)
       warden_params = devise_parameter_filter.filter(warden_params.to_h.symbolize_keys)
       email = warden_params[:email]

--- a/app/models/folio/user.rb
+++ b/app/models/folio/user.rb
@@ -392,7 +392,10 @@ class Folio::User < Folio::ApplicationRecord
 
   private
     # Override of Devise method to scope authentication by zone.
+    # Apply Devise case_insensitive_keys / strip_whitespace_keys here: this
+    # method replaces the default lookup, so Warden does not run the filter.
     def self.find_for_authentication(warden_params)
+      warden_params = devise_parameter_filter.filter(warden_params.to_h.symbolize_keys)
       email = warden_params[:email]
       site = ::Folio::Current.enabled_site_for_crossdomain_devise || ::Folio::Site.find(warden_params[:auth_site_id])
 

--- a/test/cells/folio/devise/sessions/new_cell_test.rb
+++ b/test/cells/folio/devise/sessions/new_cell_test.rb
@@ -8,5 +8,8 @@ class Folio::Devise::Sessions::NewCellTest < Cell::TestCase
                 resource: Folio::User.new,
                 resource_name: :user).(:show)
     assert html.has_css?(".f-devise-sessions-new")
+    assert html.has_css?('input[name="user[email]"][type="email"]')
+    assert html.has_css?('input[name="user[email]"][autocapitalize="none"]')
+    assert html.has_css?('input[name="user[email]"][autocomplete="email"]')
   end
 end

--- a/test/controllers/folio/users/sessions_controller_test.rb
+++ b/test/controllers/folio/users/sessions_controller_test.rb
@@ -56,9 +56,18 @@ class Folio::Users::SessionsControllerTest < ActionDispatch::IntegrationTest
     skip unless Rails.application.config.folio_users_publicly_invitable
     user = Folio::User.invite!(email: "invite@email.email", auth_site_id: ::Folio::Current.site.id)
     old_timestamp = user.invitation_created_at
-    post main_app.user_session_path, params: { user: { email: "invite@email.email" } }
+    post main_app.user_session_path, params: { user: { email: "Invite@Email.Email" } }
     assert_redirected_to user_invitation_path
     assert_not_equal old_timestamp, user.reload.invitation_created_at
+  end
+
+  test "create pending invitation is scoped to the current auth site" do
+    skip unless Rails.application.config.folio_users_publicly_invitable
+    other_site = create_site(force: true)
+    Folio::User.invite!(email: "invite@email.email", auth_site_id: other_site.id)
+
+    post main_app.user_session_path, params: { user: { email: "Invite@Email.Email" } }
+    assert_redirected_to main_app.new_user_session_path
   end
 
   test "ajax create pending invitation" do

--- a/test/controllers/folio/users/sessions_controller_test.rb
+++ b/test/controllers/folio/users/sessions_controller_test.rb
@@ -27,6 +27,26 @@ class Folio::Users::SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to controller.after_sign_in_path_for(@user)
   end
 
+  test "create matches email case-insensitively" do
+    assert_difference("@user.reload.sign_in_count", 1) do
+      post main_app.user_session_path, params: {
+        user: { email: "Email@Email.Email", password: TEST_PASSWORD },
+      }
+    end
+
+    assert_redirected_to controller.after_sign_in_path_for(@user)
+  end
+
+  test "create strips surrounding whitespace from email" do
+    assert_difference("@user.reload.sign_in_count", 1) do
+      post main_app.user_session_path, params: {
+        user: { email: " #{@params[:email]} ", password: TEST_PASSWORD },
+      }
+    end
+
+    assert_redirected_to controller.after_sign_in_path_for(@user)
+  end
+
   test "ajax create" do
     post main_app.user_session_path(format: :json), params: { user: @params }
     assert_response(:ok)

--- a/test/models/folio/user_test.rb
+++ b/test/models/folio/user_test.rb
@@ -174,4 +174,14 @@ class Folio::UserTest < ActiveSupport::TestCase
     user.password = "Short, but 2 complex!"
     assert user.valid?
   end
+
+  test "find_for_authentication matches email case-insensitively and strips whitespace" do
+    user = create(:folio_user, email: "user@example.com")
+    auth_site_id = user.auth_site_id.to_s
+
+    assert_equal user, Folio::User.find_for_authentication(email: "user@example.com", auth_site_id:)
+    assert_equal user, Folio::User.find_for_authentication(email: "User@Example.COM", auth_site_id:)
+    assert_equal user, Folio::User.find_for_authentication(email: " user@example.com ", auth_site_id:)
+    assert_nil Folio::User.find_for_authentication(email: "other@example.com", auth_site_id:)
+  end
 end


### PR DESCRIPTION
## Problem

`Folio::User.find_for_authentication` replaces Devise's default lookup so authentication can be scoped by site. Because it calls `find_by(email:)` on the raw Warden params, it skips Devise's `case_insensitive_keys` and `strip_whitespace_keys`.

Sign-in then fails when the submitted email differs only by letter case or surrounding whitespace from the stored value. The Devise email field was also rendered as `type="text"` without `autocapitalize="none"`, so mobile keyboards often capitalize the first character.

Password reset can still succeed (it goes through Devise's filtered `find_or_initialize_with_errors`), after which sign-in fails again with invalid email or password.

## Change

- Run Warden params through `devise_parameter_filter` before the site-scoped lookup.
- Downcase and strip the email used when checking pending invitations.
- Render the Devise email field as `type="email"` with `autocapitalize="none"`.

## Tests

- `find_for_authentication` matches mixed-case and whitespace-padded emails
- Session `#create` with mixed-case / padded email increments `sign_in_count`
- Sign-in email input is `type="email"` with `autocapitalize="none"`